### PR TITLE
Jmock2: JMOCK-212 issue fixed

### DIFF
--- a/example/org/jmock/example/announcer/AnnouncerTests.java
+++ b/example/org/jmock/example/announcer/AnnouncerTests.java
@@ -1,10 +1,10 @@
 package org.jmock.example.announcer;
 
-import java.util.EventListener;
-
 import org.jmock.Expectations;
 import org.jmock.Sequence;
 import org.jmock.integration.junit3.MockObjectTestCase;
+
+import java.util.EventListener;
 
 
 public class AnnouncerTests extends MockObjectTestCase {
@@ -31,7 +31,7 @@ public class AnnouncerTests extends MockObjectTestCase {
 	public void testAnnouncesToRegisteredListenersInOrderOfAddition() {
 		final Sequence eventOrder = sequence("eventOrder");
 		
-		checking(new Expectations() {{
+		checking(new Expectations() {protected void expect() throws Exception{
 			oneOf (listener1).eventA(); inSequence(eventOrder);
 			oneOf (listener2).eventA(); inSequence(eventOrder);
 			oneOf (listener1).eventB(); inSequence(eventOrder);
@@ -43,7 +43,7 @@ public class AnnouncerTests extends MockObjectTestCase {
 	}
 	
 	public void testPassesEventArgumentsToListeners() {
-		checking(new Expectations() {{
+		checking(new Expectations() {protected void expect() throws Exception{
 			oneOf (listener1).eventWithArguments(1, 2);
 			oneOf (listener2).eventWithArguments(1, 2);
 			oneOf (listener1).eventWithArguments(3, 4);
@@ -57,7 +57,7 @@ public class AnnouncerTests extends MockObjectTestCase {
 	public void testCanRemoveListeners() {
 		announcer.removeListener(listener1);
 		
-		checking(new Expectations() {{
+		checking(new Expectations() {protected void expect() throws Exception{
 			oneOf (listener2).eventA();
 		}});
 		
@@ -65,7 +65,7 @@ public class AnnouncerTests extends MockObjectTestCase {
 	}
 	
 	public void testDoesNotAllowListenersToThrowCheckedExceptions() throws Exception {
-		checking(new Expectations() {{
+		checking(new Expectations() {protected void expect() throws Exception{
 			allowing (listener1).badEvent(); will(throwException(new CheckedException()));
 		}});
 		

--- a/example/org/jmock/example/gettingstarted/GettingStartedJUnit3.java
+++ b/example/org/jmock/example/gettingstarted/GettingStartedJUnit3.java
@@ -14,7 +14,7 @@ public class GettingStartedJUnit3 extends MockObjectTestCase {
         final String message = "message";
 
         // expectations
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf(subscriber).receive(message);
         }});
 

--- a/example/org/jmock/example/gettingstarted/GettingStartedJUnit3Mockomatic.java
+++ b/example/org/jmock/example/gettingstarted/GettingStartedJUnit3Mockomatic.java
@@ -15,7 +15,7 @@ public class GettingStartedJUnit3Mockomatic extends MockObjectTestCase {
         final String message = "message";
 
         // expectations
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf(subscriber).receive(message);
         }});
 

--- a/example/org/jmock/example/gettingstarted/GettingStartedJUnit4.java
+++ b/example/org/jmock/example/gettingstarted/GettingStartedJUnit4.java
@@ -22,7 +22,7 @@ public class GettingStartedJUnit4 {
         final String message = "message";
 
         // expectations
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf(subscriber).receive(message);
         }});
 

--- a/example/org/jmock/example/gettingstarted/GettingStartedJUnit4Mockomatic.java
+++ b/example/org/jmock/example/gettingstarted/GettingStartedJUnit4Mockomatic.java
@@ -22,7 +22,7 @@ public class GettingStartedJUnit4Mockomatic {
         final String message = "message";
 
         // expectations
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf(subscriber).receive(message);
         }});
 

--- a/example/org/jmock/example/gettingstarted/GettingStartedJUnit4Rule.java
+++ b/example/org/jmock/example/gettingstarted/GettingStartedJUnit4Rule.java
@@ -20,7 +20,7 @@ public class GettingStartedJUnit4Rule {
         final String message = "message";
 
         // expectations
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf(subscriber).receive(message);
         }});
 

--- a/example/org/jmock/example/gettingstarted/GettingStartedJUnit4RuleMockomatic.java
+++ b/example/org/jmock/example/gettingstarted/GettingStartedJUnit4RuleMockomatic.java
@@ -22,7 +22,7 @@ public class GettingStartedJUnit4RuleMockomatic {
         final String message = "message";
 
         // expectations
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf(subscriber).receive(message);
         }});
 

--- a/example/org/jmock/example/qcon/DJTests.java
+++ b/example/org/jmock/example/qcon/DJTests.java
@@ -17,7 +17,7 @@ public class DJTests extends MockObjectTestCase {
     
     @Override
     public void setUp() {
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             allowing (playlist).hasTrackFor(LOCATION_A); will(returnValue(true));
             allowing (playlist).trackFor(LOCATION_A); will(returnValue(TRACK_A));
             allowing (playlist).hasTrackFor(LOCATION_B); will(returnValue(true));
@@ -27,7 +27,7 @@ public class DJTests extends MockObjectTestCase {
     }
     
     public void testStartsPlayingTrackForCurrentLocationWhenLocationFirstDetected() {
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (mediaControl).play(TRACK_A);
         }});
         
@@ -39,7 +39,7 @@ public class DJTests extends MockObjectTestCase {
         
         dj.locationChangedTo(LOCATION_B);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (mediaControl).play(TRACK_B);
         }});
         
@@ -49,7 +49,7 @@ public class DJTests extends MockObjectTestCase {
     public void testDoesNotPlayTrackAgainIfStillInTheSameLocation() {
         startingIn(LOCATION_A);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             never (mediaControl).play(with(any(String.class)));
         }});
         
@@ -60,7 +60,7 @@ public class DJTests extends MockObjectTestCase {
         startingIn(LOCATION_A);
         dj.mediaFinished();
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (mediaControl).play(TRACK_B);
         }});
         
@@ -68,7 +68,7 @@ public class DJTests extends MockObjectTestCase {
     }
     
     private void startingIn(String initialLocation) {
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (mediaControl).play(with(any(String.class)));
         }});
         

--- a/example/org/jmock/example/sniper/AuctionSniperTests.java
+++ b/example/org/jmock/example/sniper/AuctionSniperTests.java
@@ -17,7 +17,7 @@ public class AuctionSniperTests extends MockObjectTestCase {
     public void testTriesToBeatTheLatestHighestBid() throws Exception {
         final Money expectedBid = beatableBid.add(increment);
 
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (auction).bid(expectedBid);
         }});
 
@@ -25,7 +25,7 @@ public class AuctionSniperTests extends MockObjectTestCase {
     }
 
     public void testWillNotBidPriceGreaterThanMaximum() throws Exception {
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             ignoring (listener);
             never (auction).bid(with(any(Money.class)));
         }});
@@ -33,7 +33,7 @@ public class AuctionSniperTests extends MockObjectTestCase {
     }
 
     public void testWillLimitBidToMaximum() throws Throwable {
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             exactly(1).of (auction).bid(maximumBid);
         }});
 
@@ -43,7 +43,7 @@ public class AuctionSniperTests extends MockObjectTestCase {
     public void testWillNotBidWhenToldAboutBidsOnOtherItems() throws Throwable {
         final Auction otherLot = mock(Auction.class, "otherLot");
 
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
            never (otherLot).bid(new Money(10));
         }});
 
@@ -51,7 +51,7 @@ public class AuctionSniperTests extends MockObjectTestCase {
     }
 
     public void testWillAnnounceItHasFinishedIfPriceGoesAboveMaximum() {
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             exactly(1).of (listener).sniperFinished(sniper);
         }});
 
@@ -61,7 +61,7 @@ public class AuctionSniperTests extends MockObjectTestCase {
     public void testCatchesExceptionsAndReportsThemToErrorListener() throws Exception {
         final AuctionException exception = new AuctionException("test");
 
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             allowing (auction).bid(with(any(Money.class))); 
                 will(throwException(exception));
             exactly(1).of (listener).sniperBidFailed(sniper, exception);

--- a/example/org/jmock/example/timedcache/TimedCacheTests.java
+++ b/example/org/jmock/example/timedcache/TimedCacheTests.java
@@ -34,7 +34,7 @@ public class TimedCacheTests extends TestCase {
         final Object VALUE1 = "value1";
         final Object VALUE2 = "value2";
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             allowing (clock).time(); will(returnValue(loadTime));
 
             oneOf (loader).load("key1"); will(returnValue(VALUE1));
@@ -50,7 +50,7 @@ public class TimedCacheTests extends TestCase {
     }
 
     public void testReturnsCachedObjectWithinTimeout() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf (clock).time(); will(returnValue(loadTime));
             oneOf (clock).time(); will(returnValue(fetchTime));
             
@@ -68,7 +68,7 @@ public class TimedCacheTests extends TestCase {
     }
 
     public void testReloadsCachedObjectAfterTimeout() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             allowing (reloadPolicy).shouldReload(loadTime, fetchTime); will(returnValue(true));
             
             oneOf (clock).time(); will(returnValue(loadTime));

--- a/src/org/jmock/Expectations.java
+++ b/src/org/jmock/Expectations.java
@@ -1,9 +1,9 @@
 package org.jmock;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.IsAnything;
@@ -13,6 +13,7 @@ import org.hamcrest.core.IsNot;
 import org.hamcrest.core.IsNull;
 import org.hamcrest.core.IsSame;
 import org.jmock.api.Action;
+import org.jmock.internal.BoxingUtils;
 import org.jmock.internal.Cardinality;
 import org.jmock.internal.ChangeStateSideEffect;
 import org.jmock.internal.ExpectationBuilder;
@@ -37,299 +38,301 @@ import org.jmock.syntax.WithClause;
 /**
  * Provides most of the syntax of jMock's "domain-specific language" API.
  * The methods of this class don't make any sense on their own, so the
- * Javadoc is rather sparse.  Consult the documentation on the jMock 
+ * Javadoc is rather sparse.  Consult the documentation on the jMock
  * website for information on how to use this API.
- * 
- * @author nat
  *
+ * @author nat
  */
-public class Expectations implements ExpectationBuilder,
-    CardinalityClause, ArgumentConstraintPhrases, ActionClause 
-{
+public abstract class Expectations implements ExpectationBuilder,
+        CardinalityClause, ArgumentConstraintPhrases, ActionClause {
     private List<InvocationExpectationBuilder> builders = new ArrayList<InvocationExpectationBuilder>();
     private InvocationExpectationBuilder currentBuilder = null;
-    
+    private boolean isBuildNow = false;
+
+    private List<Object> objectsFromWith = new ArrayList<Object>();
+    private int lastVerifiedPosInObjects = -1;
+    private int currentPosIsObjectsFromWith = -1;
+
+    private class IncompatibleClass {
+    }
+
+
+    protected abstract void expect() throws Exception;
+
+    private void build() {
+        while (true) {
+            try {
+                builders.clear();
+                currentBuilder = null;
+                expect();
+                return; // all is right
+            } catch (ClassCastException e) {
+                lastVerifiedPosInObjects++;
+                Object expectedClass = createExpectedArrayOrBoxingPrimitiveOrReturnNull(e);
+                objectsFromWith.set(lastVerifiedPosInObjects, expectedClass);
+                currentPosIsObjectsFromWith = -1;
+            } catch (Exception e) {
+                if (e instanceof RuntimeException) {
+                    throw (RuntimeException) e;
+                } else {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    private Object createExpectedArrayOrBoxingPrimitiveOrReturnNull(ClassCastException e) {
+        /*
+        should be processed correctly:
+        1) Objects
+        2) Primitives
+        3) Arrays
+        */
+        final String message = e.getMessage();
+        final int pos = message.indexOf("cannot be cast to ") + "cannot be cast to ".length();
+        final String className = message.substring(pos);
+
+        try {
+            Class<?> clazz = Class.forName(className);
+            if (clazz.isArray()) {
+                return Array.newInstance(clazz.getComponentType(), 0);
+            } else if (BoxingUtils.isWrapperType(clazz)) {
+                if (clazz.equals(Boolean.class) || clazz.equals(boolean.class)) {
+                    return false;
+                }
+                if (clazz.equals(Byte.class) || clazz.equals(byte.class)) {
+                    return (byte) 0;
+                }
+                if (clazz.equals(Character.class) || clazz.equals(char.class)) {
+                    return (char) 0;
+                }
+                if (clazz.equals(Short.class) || clazz.equals(short.class)) {
+                    return (short) 0;
+                }
+                if (clazz.equals(Integer.class) || clazz.equals(int.class)) {
+                    return 0;
+                }
+                if (clazz.equals(Long.class) || clazz.equals(long.class)) {
+                    return 0L;
+                }
+                if (clazz.equals(Float.class) || clazz.equals(float.class)) {
+                    return 0.0f;
+                }
+                if (clazz.equals(Double.class) || clazz.equals(double.class)) {
+                    return 0.0d;
+                }
+
+                throw new IllegalStateException("Unknown wrapper type: "+clazz);
+            } else {
+                return null;
+            }
+        } catch (ClassNotFoundException e1) {
+            throw new RuntimeException(e1);
+        }
+    }
+
+    private Object getObjectFromWith() {
+        currentPosIsObjectsFromWith++;
+        if (objectsFromWith.size() == currentPosIsObjectsFromWith) {
+            objectsFromWith.add(new IncompatibleClass());
+        }
+        return objectsFromWith.get(currentPosIsObjectsFromWith);
+    }
+
+    private void checkWeBuildingNow() {
+        if (!isBuildNow) {
+            throw new IllegalStateException("You should specify expectations only in 'expect(){...} method'");
+        }
+    }
+
     protected final WithClause with = new WithClause() {
         public boolean booleanIs(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return false;
+            return (Boolean) with(matcher);// ClassCastException is expected here
         }
 
         public byte byteIs(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return 0;
+            return (Byte) with(matcher); // ClassCastException is expected here
         }
 
         public char charIs(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return 0;
+            return (Character) with(matcher);// ClassCastException is expected here
         }
 
         public double doubleIs(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return 0;
+            return (Double) with(matcher);// ClassCastException is expected here
         }
 
         public float floatIs(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return 0;
+            return (Float) with(matcher);// ClassCastException is expected here
         }
 
         public int intIs(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return 0;
+            return (Integer) with(matcher);// ClassCastException is expected here
         }
 
         public long longIs(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return 0;
+            return (Long) with(matcher);// ClassCastException is expected here
         }
 
         public short shortIs(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return 0;
+            return (Short) with(matcher);// ClassCastException is expected here
         }
 
         public <T> T is(Matcher<?> matcher) {
-            addParameterMatcher(matcher);
-            return null;
+            return (T) with(matcher);// ClassCastException may be thrown here
         }
     };
-    
-    
+
+
+    {
+        isBuildNow = true;
+        build();
+        isBuildNow = false;
+    }
+
+
     private void initialiseExpectationCapture(Cardinality cardinality) {
         checkLastExpectationWasFullySpecified();
-        
+
         currentBuilder = new InvocationExpectationBuilder();
         currentBuilder.setCardinality(cardinality);
         builders.add(currentBuilder);
     }
-    
+
     public void buildExpectations(Action defaultAction, ExpectationCollector collector) {
         checkLastExpectationWasFullySpecified();
-        
+
         for (InvocationExpectationBuilder builder : builders) {
             collector.add(builder.toExpectation(defaultAction));
         }
     }
-    
+
     protected InvocationExpectationBuilder currentBuilder() {
         if (currentBuilder == null) {
             throw new IllegalStateException("no expectations have been specified " +
-                "(did you forget to to specify the cardinality of the first expectation?)");
+                    "(did you forget to to specify the cardinality of the first expectation?)");
         }
         return currentBuilder;
     }
-    
+
     private void checkLastExpectationWasFullySpecified() {
         if (currentBuilder != null) {
             currentBuilder.checkWasFullySpecified();
         }
     }
-    
+
     /* 
      * Syntactic sugar
      */
-    
+
     public ReceiverClause exactly(int count) {
+        checkWeBuildingNow();
         initialiseExpectationCapture(Cardinality.exactly(count));
         return currentBuilder;
     }
-    
+
     // Makes the entire expectation more readable than one
     public <T> T oneOf(T mockObject) {
+        checkWeBuildingNow();
         return exactly(1).of(mockObject);
     }
-    
+
     /**
      * @deprecated Use {@link #oneOf(Object) oneOf} instead.
      */
-    public <T> T one (T mockObject) {
+    public <T> T one(T mockObject) {
+        checkWeBuildingNow();
         return oneOf(mockObject);
     }
-    
+
     public ReceiverClause atLeast(int count) {
+        checkWeBuildingNow();
         initialiseExpectationCapture(Cardinality.atLeast(count));
         return currentBuilder;
     }
-    
+
     public ReceiverClause between(int minCount, int maxCount) {
+        checkWeBuildingNow();
         initialiseExpectationCapture(Cardinality.between(minCount, maxCount));
         return currentBuilder;
     }
-    
+
     public ReceiverClause atMost(int count) {
+        checkWeBuildingNow();
         initialiseExpectationCapture(Cardinality.atMost(count));
         return currentBuilder;
     }
-    
+
     public MethodClause allowing(Matcher<?> mockObjectMatcher) {
+        checkWeBuildingNow();
         return atLeast(0).of(mockObjectMatcher);
     }
-    
+
     public <T> T allowing(T mockObject) {
+        checkWeBuildingNow();
         return atLeast(0).of(mockObject);
     }
-    
+
     public <T> T ignoring(T mockObject) {
+        checkWeBuildingNow();
         return allowing(mockObject);
     }
-    
+
     public MethodClause ignoring(Matcher<?> mockObjectMatcher) {
+        checkWeBuildingNow();
         return allowing(mockObjectMatcher);
     }
-    
+
     public <T> T never(T mockObject) {
+        checkWeBuildingNow();
         return exactly(0).of(mockObject);
     }
-    
+
     private void addParameterMatcher(Matcher<?> matcher) {
+        checkWeBuildingNow();
         currentBuilder().addParameterMatcher(matcher);
     }
-    
+
     /**
      * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
      */
     public <T> T with(Matcher<T> matcher) {
+        checkWeBuildingNow();
         addParameterMatcher(matcher);
-        return null;
-    }
-    
-    /**
-     * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
-     */
-    public boolean with(Matcher<Boolean> matcher) {
-        addParameterMatcher(matcher);
-        return false;
-    }
-    
-    /**
-     * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
-     */
-    public byte with(Matcher<Byte> matcher) {
-        addParameterMatcher(matcher);
-        return 0;
+        return (T) getObjectFromWith();
     }
 
-    /**
-     * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
-     */
-    public short with(Matcher<Short> matcher) {
-        addParameterMatcher(matcher);
-        return 0;
-    }
-
-    /**
-     * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
-     */
-    public char with(Matcher<Character> matcher) {
-        addParameterMatcher(matcher);
-        return 0;
-    }
-    
-    /**
-     * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
-     */
-    public int with(Matcher<Integer> matcher) {
-        addParameterMatcher(matcher);
-        return 0;
-    }
-
-    /**
-     * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
-     */
-    public long with(Matcher<Long> matcher) {
-        addParameterMatcher(matcher);
-        return 0;
-    }
-
-    /**
-     * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
-     */
-    public float with(Matcher<Float> matcher) {
-        addParameterMatcher(matcher);
-        return 0.0f;
-    }
-
-    /**
-     * Alternatively, use with.<T>is instead, which will work with untyped Hamcrest matchers
-     */
-    public double with(Matcher<Double> matcher) {
-        addParameterMatcher(matcher);
-        return 0.0;
-    }
-    
-    public boolean with(boolean value) {
-        addParameterMatcher(equal(value));
-        return false;
-    }
-    
-    public byte with(byte value) {
-        addParameterMatcher(equal(value));
-        return 0;
-    }
-    
-    public short with(short value) {
-        addParameterMatcher(equal(value));
-        return 0;
-    }
-    
-    public char with(char value) {
-        addParameterMatcher(equal(value));
-        return 0;
-    }
-    
-    public int with(int value) {
-        addParameterMatcher(equal(value));
-        return 0;
-    }
-    
-    public long with(long value) {
-        addParameterMatcher(equal(value));
-        return 0;
-    }
-    
-    public float with(float value) {
-        addParameterMatcher(equal(value));
-        return 0;
-    }
-    
-    public double with(double value) {
-        addParameterMatcher(equal(value));
-        return 0;
-    }
-    
     public <T> T with(T value) {
-        addParameterMatcher(equal(value));
-        return value;
+        checkWeBuildingNow();
+        return with(equal(value));
     }
-    
+
     public void will(Action action) {
+        checkWeBuildingNow();
         currentBuilder().setAction(action);
     }
-    
+
     /* Common constraints
      */
-    
+
     public static <T> Matcher<T> equal(T value) {
         return new IsEqual<T>(value);
     }
-    
+
     public static <T> Matcher<T> same(T value) {
         return new IsSame<T>(value);
     }
-    
+
     public static <T> Matcher<T> any(Class<T> type) {
         return CoreMatchers.any(type);
     }
-    
+
     public static <T> Matcher<T> anything() {
         return new IsAnything<T>();
     }
-    
+
     /**
-     * @deprecated 
-     *  use {@link #aNonNull} or {@link #any} until type inference actually works in a future version of Java
+     * @deprecated use {@link #aNonNull} or {@link #any} until type inference actually works in a future version of Java
      */
     @Deprecated
     public static Matcher<Object> a(Class<?> type) {
@@ -337,73 +340,76 @@ public class Expectations implements ExpectationBuilder,
     }
 
     /**
-     * @deprecated 
-     *  use {@link #aNonNull} or {@link #any} until type inference actually works in a future version of Java
+     * @deprecated use {@link #aNonNull} or {@link #any} until type inference actually works in a future version of Java
      */
     @Deprecated
     public static Matcher<Object> an(Class<?> type) {
         return new IsInstanceOf(type);
     }
-    
+
     public static <T> Matcher<T> aNull(@SuppressWarnings("unused") Class<T> type) {
         return new IsNull<T>();
     }
-    
+
     public static <T> Matcher<T> aNonNull(@SuppressWarnings("unused") Class<T> type) {
         return new IsNot<T>(new IsNull<T>());
     }
-    
+
     /* Common actions
      */
-    
+
     public static Action returnValue(Object result) {
         return new ReturnValueAction(result);
     }
-    
+
     public static Action throwException(Throwable throwable) {
         return new ThrowAction(throwable);
     }
-    
+
     public static Action returnIterator(Collection<?> collection) {
         return new ReturnIteratorAction(collection);
     }
-    
-    public static <T> Action returnIterator(T ... items) {
+
+    public static <T> Action returnIterator(T... items) {
         return new ReturnIteratorAction(items);
     }
-    
+
     public static Action returnEnumeration(Collection<?> collection) {
         return new ReturnEnumerationAction(collection);
     }
-    
-    public static <T> Action returnEnumeration(T ... items) {
+
+    public static <T> Action returnEnumeration(T... items) {
         return new ReturnEnumerationAction(items);
     }
-    
-    public static Action doAll(Action...actions) {
+
+    public static Action doAll(Action... actions) {
         return new DoAllAction(actions);
     }
-    
-    public static Action onConsecutiveCalls(Action...actions) {
+
+    public static Action onConsecutiveCalls(Action... actions) {
         return new ActionSequence(actions);
     }
-    
+
     /* Naming and ordering
      */
-    
+
     public void when(StatePredicate predicate) {
+        checkWeBuildingNow();
         currentBuilder().addOrderingConstraint(new InStateOrderingConstraint(predicate));
     }
-    
+
     public void then(State state) {
+        checkWeBuildingNow();
         currentBuilder().addSideEffect(new ChangeStateSideEffect(state));
     }
-    
+
     public void inSequence(Sequence sequence) {
+        checkWeBuildingNow();
         currentBuilder().addInSequenceOrderingConstraint(sequence);
     }
 
     public void inSequences(Sequence... sequences) {
+        checkWeBuildingNow();
         for (Sequence sequence : sequences) {
             inSequence(sequence);
         }

--- a/src/org/jmock/integration/junit4/JUnitRuleMockery.java
+++ b/src/org/jmock/integration/junit4/JUnitRuleMockery.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
  *     
  *  @Test
  *  public void doesSatisfyExpectations() {
- *    context.checking(new Expectations() {{
+ *    context.checking(new Expectations() {protected void expect() throws Exception{
  *      oneOf (runnable).run();
  *    }});
  *          

--- a/src/org/jmock/integration/junit4/package.html
+++ b/src/org/jmock/integration/junit4/package.html
@@ -27,9 +27,11 @@ public class ExampleJUnit4MockObjectTest {
 	dispatchesEventToSessionsOtherThanThenSender() {
 		...
 		
-		context.checking(new Expectations() {{
-			...
-		}});
+		context.checking(new Expectations() {
+    		protected void expect() throws Exception{
+				...
+			}
+    	});
 		
 		...
 	}
@@ -46,9 +48,11 @@ assert the expectations after each test has run.</p>
      
   @Test
   public void doesSatisfyExpectations() {
-    context.checking(new Expectations() {{
-      oneOf (runnable).run();
-    }});
+    context.checking(new Expectations() {
+    	protected void expect() throws Exception{
+      		oneOf (runnable).run();
+    	}
+    });
           
     runnable.run();
   }

--- a/src/org/jmock/internal/BoxingUtils.java
+++ b/src/org/jmock/internal/BoxingUtils.java
@@ -1,0 +1,22 @@
+package org.jmock.internal;
+
+
+import java.util.HashSet;
+
+public class BoxingUtils {
+    private static final HashSet<Class<?>> WRAPPER_TYPES = new HashSet<Class<?>>() {{
+        add(Boolean.class);
+        add(Character.class);
+        add(Byte.class);
+        add(Short.class);
+        add(Integer.class);
+        add(Long.class);
+        add(Float.class);
+        add(Double.class);
+        add(Void.class);
+    }};
+
+    public static boolean isWrapperType(Class<?> clazz) {
+        return WRAPPER_TYPES.contains(clazz);
+    }
+}

--- a/src/org/jmock/syntax/ArgumentConstraintPhrases.java
+++ b/src/org/jmock/syntax/ArgumentConstraintPhrases.java
@@ -4,11 +4,4 @@ import org.hamcrest.Matcher;
 
 public interface ArgumentConstraintPhrases {
     <T> T with(Matcher<T> matcher);
-    boolean with(Matcher<Boolean> matcher);
-    byte with(Matcher<Byte> matcher);
-    short with(Matcher<Short> matcher);
-    int with(Matcher<Integer> matcher);
-    long with(Matcher<Long> matcher);
-    float with(Matcher<Float> matcher);
-    double with(Matcher<Double> matcher);
 }

--- a/test/org/jmock/test/acceptance/AnyMethodAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/AnyMethodAcceptanceTests.java
@@ -16,7 +16,7 @@ public class AnyMethodAcceptanceTests extends TestCase {
     AnotherType anotherMock = context.mock(AnotherType.class, "anotherMock");
     
     public void testElidingTheMethodMeansAnyMethodWithAnyArguments() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock);
         }});
         
@@ -27,7 +27,7 @@ public class AnyMethodAcceptanceTests extends TestCase {
     }
     
     public void testCanElideMethodsOfMoreThanOneMockObject() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             ignoring (mock);
             ignoring (anotherMock);
         }});

--- a/test/org/jmock/test/acceptance/ArrayParameterTypesAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ArrayParameterTypesAcceptanceTests.java
@@ -1,0 +1,55 @@
+package org.jmock.test.acceptance;
+
+import junit.framework.TestCase;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+
+public class ArrayParameterTypesAcceptanceTests extends TestCase {
+    public interface MethodsWithPrimitiveTypes {
+        void withPrimitiveArray(boolean[] boolAr, byte[] byteAr, short[] shortAr, int[] intAr, long[] longAr, float[] floatAr, double[] doubleAr);
+        void withObjectArray(Object objectAr[]);
+    }
+    
+    Mockery context = new Mockery();
+    MethodsWithPrimitiveTypes mock = context.mock(MethodsWithPrimitiveTypes.class, "mock");
+
+    private final boolean[] boolAr = new boolean[]{true, false};
+    private final byte[] byteAr = new byte[]{42, 43};
+    private final short[] shortAr = new short[]{256, 300};
+    private final int[] intAr = new int[]{65598, 7878787};
+    private final long[] longAr = new long[]{Long.MAX_VALUE, Long.MIN_VALUE};
+    private final float[] floatAr = new float[]{1.0f, 2.0f};
+    private final double[] doubleAr = new double[]{3.0d, 4.0d};
+    private final Object[] objectAr = new Object[]{new Object(), new Object()};
+    
+    public void testCanSetExpectationsWithMatchersForMethodsWithArgumentsOfPrimitiveTypes() {
+        context.checking(new Expectations() {protected void expect() throws Exception {
+            exactly(1).of (mock).withPrimitiveArray(
+                    with(equal(boolAr)),
+                    with(equal(byteAr)),
+                    with(equal(shortAr)),
+                    with(equal(intAr)),
+                    with(equal(longAr)),
+                    with(equal(floatAr)),
+                    with(equal(doubleAr)));
+            exactly(1).of(mock).withObjectArray(with(equal(objectAr)));
+        }});
+        
+        mock.withPrimitiveArray(boolAr, byteAr, shortAr, intAr, longAr, floatAr, doubleAr);
+        mock.withObjectArray(objectAr);
+        
+        context.assertIsSatisfied();
+    }
+
+    public void testCanSetExpectationsWithLiteralsForMethodsWithArgumentsOfPrimitiveTypes() {
+        context.checking(new Expectations() {protected void expect() throws Exception {
+            exactly(1).of (mock).withPrimitiveArray(boolAr, byteAr, shortAr, intAr, longAr, floatAr, doubleAr);
+            exactly(1).of(mock).withObjectArray(with(equal(objectAr)));
+        }});
+
+        mock.withPrimitiveArray(boolAr, byteAr, shortAr, intAr, longAr, floatAr, doubleAr);
+        mock.withObjectArray(objectAr);
+        
+        context.assertIsSatisfied();
+    }
+}

--- a/test/org/jmock/test/acceptance/CascadedFailuresAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/CascadedFailuresAcceptanceTests.java
@@ -32,7 +32,7 @@ public class CascadedFailuresAcceptanceTests extends TestCase {
     
     @Override
     public void setUp() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).realExpectationFailure(1);
         }});
     }

--- a/test/org/jmock/test/acceptance/ConsecutiveCallsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ConsecutiveCallsAcceptanceTests.java
@@ -14,7 +14,7 @@ public class ConsecutiveCallsAcceptanceTests extends TestCase {
     
     
     public void testCanEasilySpecifySequenceOfStubsForSameMethod() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             atLeast(1).of (mock).returnString();
                 will(onConsecutiveCalls(returnValue("hello"),
                                         returnValue("bonjour"),

--- a/test/org/jmock/test/acceptance/DefineExpectationWithinExpectationsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/DefineExpectationWithinExpectationsAcceptanceTests.java
@@ -21,7 +21,7 @@ public class DefineExpectationWithinExpectationsAcceptanceTests extends TestCase
     MockedTypeA a = context.mock(MockedTypeA.class, "a");
     
     public void testCanDefineExpectationsWithinExpectations() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (a).a(aNewMockWithExpectations());
         }});
     }
@@ -29,7 +29,7 @@ public class DefineExpectationWithinExpectationsAcceptanceTests extends TestCase
     private MockedTypeB aNewMockWithExpectations() {
         final MockedTypeB mock = context.mock(MockedTypeB.class);
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             ignoring (mock);
         }});
             
@@ -39,7 +39,7 @@ public class DefineExpectationWithinExpectationsAcceptanceTests extends TestCase
     public void testCanStillIgnoreEntireMockObjectsBeforeAnotherExpectation() {
         final MockedTypeA a2 = context.mock(MockedTypeA.class, "a2");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             ignoring(a2);
             oneOf (a).a(aNewMockWithExpectations());
         }});

--- a/test/org/jmock/test/acceptance/DoAllAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/DoAllAcceptanceTests.java
@@ -1,15 +1,14 @@
 package org.jmock.test.acceptance;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import junit.framework.TestCase;
-
 import org.hamcrest.Description;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.api.Action;
 import org.jmock.api.Invocation;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class DoAllAcceptanceTests extends TestCase {
     public interface Collector {
@@ -23,7 +22,7 @@ public class DoAllAcceptanceTests extends TestCase {
     public void testCanSpecifyMultipleStubsForOneInvocation() {
         final ArrayList<String> list = new ArrayList<String>();
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (collector).addThingsTo(with(same(list)));
             	will(doAll(addElement("1"), 
                            addElement("2"), 

--- a/test/org/jmock/test/acceptance/ErrorMessagesAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ErrorMessagesAcceptanceTests.java
@@ -21,7 +21,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
     MockedType mock = context.mock(MockedType.class, "mock");
     
     public void testShowsExpectedAndCurrentNumberOfCallsInErrorMessage() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).method1();
             exactly(1).of (mock).method2();
             atLeast(1).of (mock).method3();
@@ -51,7 +51,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
 
     // See issue JMOCK-132
     public void testErrorMessageIncludesNotInvokedInsteadOfInvokedExactly0Times() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).method1();
         }});
         
@@ -68,7 +68,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
     
     // See issue JMOCK-153
     public void testErrorMessageIncludesOnceInsteadOfExactly1Time() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).method1();
         }});
         
@@ -86,7 +86,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
     // See issue JMOCK-190
     public void testCannotExpectToString() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 allowing(mock).toString();
             }});
             fail("should have thrown IllegalArgumentException");
@@ -97,7 +97,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
     // See issue JMOCK-190
     public void testCannotExpectEquals() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 allowing(mock).equals("any object");
             }});
             fail("should have thrown IllegalArgumentException");
@@ -108,7 +108,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
     // See issue JMOCK-190
     public void testCannotExpectHashCode() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 allowing(mock).hashCode();
             }});
             fail("should have thrown IllegalArgumentException");
@@ -125,7 +125,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
         final TypeThatMakesFinalizePublic mockWithFinalize = context.mock(TypeThatMakesFinalizePublic.class, "mockWithFinalize");
         
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 allowing(mockWithFinalize).finalize();
             }});
             fail("should have thrown IllegalArgumentException");
@@ -135,7 +135,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
     
     // See issue JMOCK-167
     public void testDoesNotDescribeReturnValueForMethodsThatAreKnownToBeVoid() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomething();
         }});
         
@@ -144,7 +144,7 @@ public class ErrorMessagesAcceptanceTests extends TestCase {
     }
 
     public void testMismatchDescription() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWith("foo");
             oneOf (mock).doSomethingWith("x", "y"); will(doSomethingDescribedAs("ACTION"));
         }});

--- a/test/org/jmock/test/acceptance/ExpectationCountsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ExpectationCountsAcceptanceTests.java
@@ -12,7 +12,7 @@ public class ExpectationCountsAcceptanceTests extends TestCase {
     MockedType mock = context.mock(MockedType.class, "mock");
     
     public void testOne() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomething();
         }});
         
@@ -23,7 +23,7 @@ public class ExpectationCountsAcceptanceTests extends TestCase {
     }
     
     public void testExpectsExactly() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(2).of (mock).doSomething();
         }});
         
@@ -36,7 +36,7 @@ public class ExpectationCountsAcceptanceTests extends TestCase {
     }
     
     public void testExpectsAtLeast() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             atLeast(2).of (mock).doSomething();
         }});
         
@@ -53,7 +53,7 @@ public class ExpectationCountsAcceptanceTests extends TestCase {
     }
     
     public void testExpectsAtMost() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             atMost(2).of (mock).doSomething();
         }});
         
@@ -65,7 +65,7 @@ public class ExpectationCountsAcceptanceTests extends TestCase {
     }
     
     public void testExpectsBetween() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             between(2,3).of (mock).doSomething();
         }});
         
@@ -81,7 +81,7 @@ public class ExpectationCountsAcceptanceTests extends TestCase {
     }
     
     public void testAllows() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomething();
         }});
         
@@ -92,7 +92,7 @@ public class ExpectationCountsAcceptanceTests extends TestCase {
     }
     
     public void testNever() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             never (mock).doSomething();
         }});
         

--- a/test/org/jmock/test/acceptance/ExpectationErrorCheckingAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ExpectationErrorCheckingAcceptanceTests.java
@@ -16,7 +16,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
         final ArrayList<String> list = new ArrayList<String>();
         
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 exactly(1).of (list).add("a new element");
             }});
             
@@ -29,7 +29,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
     
     public void testCannotSetAnExpectationWithoutSpecifyingCardinality() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 mock.doSomething();
             }});
             fail("should have thrown ExpectationError");
@@ -41,7 +41,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
     
     public void testCannotSetAnExpectationWithoutSpecifyingCardinalityAfterPreviousExpectationsWithCardinality() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 exactly(1).of (mock).doSomething();
                 mock.doSomething();
             }});
@@ -54,7 +54,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
     
     public void testCannotSetAnExpectationWithoutSpecifyingCardinalityAfterAnIncompleteExpectation() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 exactly(1);
                 mock.doSomething();
             }});
@@ -67,7 +67,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
     
     public void testCannotSetAnExpectationWithoutSpecifyingTheMockObject() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 exactly(1);
             }});
             fail("should have thrown IllegalStateException");
@@ -79,7 +79,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
     
     public void testCannotSetAnExpectationWithoutSpecifyingTheMockObjectBeforeOtherExpectations() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 exactly(1);
                 exactly(1).of (mock).doSomething();
             }});
@@ -92,7 +92,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
     
     public void testCannotSetAnExpectationWithoutSpecifyingTheMockObjectAfterOtherExpectations() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 exactly(1).of (mock).doSomething();
                 exactly(1);
             }});
@@ -105,7 +105,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
     
     public void testCannotSetExpectationWithoutSpecifyingTheMockObjectWhenSettingParameterConstraints() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 mock.doSomethingWith(with(equal("1")), with(equal("2")));
             }});
         }
@@ -126,7 +126,7 @@ public class ExpectationErrorCheckingAcceptanceTests extends TestCase {
     
     public void testMustSpecifyConstraintsForAllArguments() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 exactly(1).of (mock).doSomethingWith("x", with(equal("y")));
             }});
             fail("should have thrown IllegalArgumentException");

--- a/test/org/jmock/test/acceptance/ExpectationErrorTranslationAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ExpectationErrorTranslationAcceptanceTests.java
@@ -26,7 +26,7 @@ public class ExpectationErrorTranslationAcceptanceTests extends TestCase {
     }
     
     public void testMockeryCanTranslateExpectationErrorsIntoDifferentExceptionTypeWhenUnexpectedInvocationOccurs() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).method1();
         }});
         
@@ -42,7 +42,7 @@ public class ExpectationErrorTranslationAcceptanceTests extends TestCase {
     }
     
     public void testMockeryCanTranslateExpectationErrorsIntoDifferentExceptionTypeWhenMockeryIsNotSatisfied() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).method1();
         }});
         

--- a/test/org/jmock/test/acceptance/FlexibleExpectationsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/FlexibleExpectationsAcceptanceTests.java
@@ -17,7 +17,7 @@ public class FlexibleExpectationsAcceptanceTests extends TestCase {
     MockedType mock2 = context.mock(MockedType.class, "mock2");
     
     public void testCanSpecifyFlexibleMethodMatchers() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (anything()).method(withName("doSomething.*"));
         }});
         
@@ -35,7 +35,7 @@ public class FlexibleExpectationsAcceptanceTests extends TestCase {
     }
     
     public void testCanSpecifyMethodNameRegexDirectly() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (anything()).method("doSomething.*");
         }});
         
@@ -53,7 +53,7 @@ public class FlexibleExpectationsAcceptanceTests extends TestCase {
     }
 
     public void testCanSpecifyFlexibleArgumentMatchers() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (anything()).method(withName("doSomethingWith")).with(equal("x"), equal("y"));
             allowing (anything()).method(withName("doSomethingWith")).with(equal("X"), equal("Y"));
         }});
@@ -73,7 +73,7 @@ public class FlexibleExpectationsAcceptanceTests extends TestCase {
     }
     
     public void testCanSpecifyNoArguments() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (anything()).method(withName("do.*")).withNoArguments();
             allowing (anything()).method(withName("do.*")).with(equal("X"), equal("Y"));
         }});
@@ -91,7 +91,7 @@ public class FlexibleExpectationsAcceptanceTests extends TestCase {
     }
     
     public void testCanReturnDefaultValueFromFlexibleExpectation() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (anything()).method(withName(".*"));
         }});
         

--- a/test/org/jmock/test/acceptance/HamcrestTypeSafetyAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/HamcrestTypeSafetyAcceptanceTests.java
@@ -22,7 +22,7 @@ public class HamcrestTypeSafetyAcceptanceTests extends TestCase {
     MockedType mock = context.mock(MockedType.class, "mock");
     
     public void testMatchersCanCopeWithDifferentArgumentTypes() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (anything()).method(withName("m")).with(startsWith("x"));
             exactly(1).of (anything()).method(withName("m")).with(greaterThan(0));
         }});

--- a/test/org/jmock/test/acceptance/MockingClassesAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/MockingClassesAcceptanceTests.java
@@ -24,7 +24,7 @@ public class MockingClassesAcceptanceTests extends TestCase {
     public void testCanMockClassesWithMethodsThatReturnFinalClasses() {
         final FinalClass result = new FinalClass();
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).returnInstanceOfFinalClass(); will(returnValue(result));
         }});
         

--- a/test/org/jmock/test/acceptance/MockingImplementationOfGenericTypeAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/MockingImplementationOfGenericTypeAcceptanceTests.java
@@ -16,7 +16,7 @@ public class MockingImplementationOfGenericTypeAcceptanceTests extends TestCase 
     public void testWhenDefinedAndInvokedThroughClass() throws Exception {
         final AnImplementation mock = context.mock(AnImplementation.class);
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWith("a");
         }});
             
@@ -26,7 +26,7 @@ public class MockingImplementationOfGenericTypeAcceptanceTests extends TestCase 
     public void testWhenDefinedThroughClassAndInvokedThroughMethod() throws Exception {
         final AnImplementation mock = context.mock(AnImplementation.class);
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWith("a");
         }});
         
@@ -39,7 +39,7 @@ public class MockingImplementationOfGenericTypeAcceptanceTests extends TestCase 
     public void testWhenDefinedAndInvokedThroughInterface() throws Exception {
         final AnInterface<String> mock = context.mock(AnImplementation.class);
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWith("a");
         }});
 

--- a/test/org/jmock/test/acceptance/NewStyleParameterMatchingAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/NewStyleParameterMatchingAcceptanceTests.java
@@ -32,7 +32,7 @@ public class NewStyleParameterMatchingAcceptanceTests extends TestCase {
     AnInterface mock = context.mock(AnInterface.class, "mock");
     
     public void testMatchesParameterValues() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWith(with.<String>is(equal("hello")));
             oneOf (mock).doSomethingWith(with.<String>is(equal("goodbye")));
         }});
@@ -44,7 +44,7 @@ public class NewStyleParameterMatchingAcceptanceTests extends TestCase {
     }
     
     public void testDoesNotAllowUnexpectedParameterValues() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWith(with.<String>is(equal("hello")));
             oneOf (mock).doSomethingWith(with.<String>is(equal("goodbye")));
         }});
@@ -59,7 +59,7 @@ public class NewStyleParameterMatchingAcceptanceTests extends TestCase {
     
     public void testAllOrNoneOfTheParametersMustBeSpecifiedByMatchers() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 oneOf (mock).doSomethingWithBoth(with.<String>is(equal("a-matcher")), "not-a-matcher");
             }});
         }
@@ -69,7 +69,7 @@ public class NewStyleParameterMatchingAcceptanceTests extends TestCase {
     
     // Test to show that issue JMOCK-160 is spurious
     public void testNotAllExpectationsOfSameMockMustUseMatchers() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWithBoth(with.<String>is(equal("x")), with.<String>is(equal("y")));
             oneOf (mock).doSomethingWith("z");
         }});
@@ -82,7 +82,7 @@ public class NewStyleParameterMatchingAcceptanceTests extends TestCase {
     
     // See issue JMOCK-161
     public void testCanPassLiteralValuesToWithMethodToMeanEqualTo() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(2).of (mock).doSomethingWithBoth(with.<String>is(anything()), with("y"));
         }});
         
@@ -94,7 +94,7 @@ public class NewStyleParameterMatchingAcceptanceTests extends TestCase {
     
     // See issue JMOCK-161
     public void testCanPassLiteralPrimitiveValuesToWithMethodToMeanEqualTo() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(2).of (mock).doSomethingWithBoth(with.booleanIs(anything()), with(true));
             exactly(2).of (mock).doSomethingWithBoth(with.byteIs(anything()), with((byte)1));
             exactly(2).of (mock).doSomethingWithBoth(with.shortIs(anything()), with((short)2));
@@ -136,7 +136,7 @@ public class NewStyleParameterMatchingAcceptanceTests extends TestCase {
         @SuppressWarnings("unused")
         final List<List<Set<String>>> silly = Collections.emptyList();
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).beSilly(with.<List<List<Set<String>>>>is(empty()));
         }});
     }

--- a/test/org/jmock/test/acceptance/NullAndNonNullAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/NullAndNonNullAcceptanceTests.java
@@ -10,7 +10,7 @@ public class NullAndNonNullAcceptanceTests extends TestCase {
     MockedType mock = context.mock(MockedType.class);
     
     public void testNullParameterMatcher() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomethingWith(with(aNull(String.class)));
         }});
         
@@ -24,7 +24,7 @@ public class NullAndNonNullAcceptanceTests extends TestCase {
     }
     
     public void testNonNullParameterMatcher() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomethingWith(with(aNonNull(String.class)));
         }});
         
@@ -39,7 +39,7 @@ public class NullAndNonNullAcceptanceTests extends TestCase {
 
     // A defect in Hamcrest
     public void DISABLED_testNullArrayParameter() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomethingWithArray(null);
         }});
 

--- a/test/org/jmock/test/acceptance/OverrideExpectationsFromSetUpAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/OverrideExpectationsFromSetUpAcceptanceTests.java
@@ -15,7 +15,7 @@ public class OverrideExpectationsFromSetUpAcceptanceTests extends TestCase {
     
     @Override
     public void setUp() {
-        mockery.checking(new Expectations() {{
+        mockery.checking(new Expectations() {protected void expect() throws Exception{
             allowing (mock).doSomethingWith(with(any(String.class))); when(test.is("settingUp"));
         }});
         
@@ -27,7 +27,7 @@ public class OverrideExpectationsFromSetUpAcceptanceTests extends TestCase {
     }
     
     public void testSomething() {
-        mockery.checking(new Expectations() {{
+        mockery.checking(new Expectations() {protected void expect() throws Exception{
             oneOf (mock).doSomethingWith("whee");
         }});
         

--- a/test/org/jmock/test/acceptance/ParameterMatchingAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ParameterMatchingAcceptanceTests.java
@@ -25,7 +25,7 @@ public class ParameterMatchingAcceptanceTests extends TestCase {
     AnInterface mock = context.mock(AnInterface.class, "mock");
     
     public void testMatchesParameterValues() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).doSomethingWith(with(equal("hello")));
             exactly(1).of (mock).doSomethingWith(with(equal("goodbye")));
         }});
@@ -37,7 +37,7 @@ public class ParameterMatchingAcceptanceTests extends TestCase {
     }
     
     public void testDoesNotAllowUnexpectedParameterValues() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).doSomethingWith(with(equal("hello")));
             exactly(1).of (mock).doSomethingWith(with(equal("goodbye")));
         }});
@@ -52,7 +52,7 @@ public class ParameterMatchingAcceptanceTests extends TestCase {
     
     public void testAllOrNoneOfTheParametersMustBeSpecifiedByMatchers() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 exactly(1).of (mock).doSomethingWithBoth(with(equal("a-matcher")), "not-a-matcher");
             }});
         }
@@ -62,7 +62,7 @@ public class ParameterMatchingAcceptanceTests extends TestCase {
     
     // Test to show that issue JMOCK-160 is spurious
     public void testNotAllExpectationsOfSameMockMustUseMatchers() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).doSomethingWithBoth(with(equal("x")), with(equal("y")));
             exactly(1).of (mock).doSomethingWith("z");
         }});
@@ -75,7 +75,7 @@ public class ParameterMatchingAcceptanceTests extends TestCase {
     
     // See issue JMOCK-161
     public void testCanPassLiteralValuesToWithMethodToMeanEqualTo() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(2).of (mock).doSomethingWithBoth(with(any(String.class)), with("y"));
         }});
         
@@ -87,17 +87,19 @@ public class ParameterMatchingAcceptanceTests extends TestCase {
     
     // See issue JMOCK-161
     public void testCanPassLiteralPrimitiveValuesToWithMethodToMeanEqualTo() {
-        context.checking(new Expectations() {{
-            exactly(2).of (mock).doSomethingWithBoth(with(any(boolean.class)), with(true));
-            exactly(2).of (mock).doSomethingWithBoth(with(any(byte.class)), with((byte)1));
-            exactly(2).of (mock).doSomethingWithBoth(with(any(short.class)), with((short)2));
-            exactly(2).of (mock).doSomethingWithBoth(with(any(char.class)), with('x'));
-            exactly(2).of (mock).doSomethingWithBoth(with(any(int.class)), with(3));
-            exactly(2).of (mock).doSomethingWithBoth(with(any(long.class)), with(4L));
-            exactly(2).of (mock).doSomethingWithBoth(with(any(float.class)), with(5.0f));
-            exactly(2).of (mock).doSomethingWithBoth(with(any(double.class)), with(6.0));
-        }});
-        
+        context.checking(new Expectations() {
+            protected void expect() throws Exception {
+                exactly(2).of(mock).doSomethingWithBoth(with(any(boolean.class)), with(true));
+                exactly(2).of(mock).doSomethingWithBoth(with(any(byte.class)), with((byte) 1));
+                exactly(2).of(mock).doSomethingWithBoth(with(any(short.class)), with((short) 2));
+                exactly(2).of(mock).doSomethingWithBoth(with(any(char.class)), with('x'));
+                exactly(2).of(mock).doSomethingWithBoth(with(any(int.class)), with(3));
+                exactly(2).of(mock).doSomethingWithBoth(with(any(long.class)), with(4L));
+                exactly(2).of(mock).doSomethingWithBoth(with(any(float.class)), with(5.0f));
+                exactly(2).of(mock).doSomethingWithBoth(with(any(double.class)), with(6.0));
+            }
+        });
+
         mock.doSomethingWithBoth(true, true);
         mock.doSomethingWithBoth(false, true);
         
@@ -127,7 +129,7 @@ public class ParameterMatchingAcceptanceTests extends TestCase {
     
     // Checking that you can do with(any(...)) with primitive types, as asked on the mailing list
     public void testSpecifyingAnyValueOfPrimitiveType() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomethingWithBoth(with(any(boolean.class)), with(any(boolean.class)));
         }});
         

--- a/test/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
@@ -20,7 +20,7 @@ public class PrimitiveParameterTypesAcceptanceTests extends TestCase {
     MethodsWithPrimitiveTypes mock = context.mock(MethodsWithPrimitiveTypes.class, "mock");
     
     public void testCanSetExpectationsWithMatchersForMethodsWithArgumentsOfPrimitiveTypes() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).withBoolean(with(equal(true)));
             exactly(1).of (mock).withByte(with(equal((byte)10)));
             exactly(1).of (mock).withShort(with(equal((short)10)));
@@ -42,7 +42,7 @@ public class PrimitiveParameterTypesAcceptanceTests extends TestCase {
     }
 
     public void testCanSetExpectationsWithLiteralsForMethodsWithArgumentsOfPrimitiveTypes() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).withBoolean(true);
             exactly(1).of (mock).withByte((byte)10);
             exactly(1).of (mock).withShort((short)10);

--- a/test/org/jmock/test/acceptance/RecordingAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/RecordingAcceptanceTests.java
@@ -16,7 +16,7 @@ public class RecordingAcceptanceTests extends TestCase {
     MockedType mock = context.mock(MockedType.class, "mock");
     
     public void testRecordsActualInvocations() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (same(mock));
         }});
         
@@ -34,7 +34,7 @@ public class RecordingAcceptanceTests extends TestCase {
     static class ExampleException extends RuntimeException {}
     
     public void testRecordsInvocationsThatThrowExceptions() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomething(); will(throwException(new ExampleException()));
         }});
         
@@ -50,7 +50,7 @@ public class RecordingAcceptanceTests extends TestCase {
     }
 
     public void testDoesNotRecordUnexpectedInvocations() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomethingWith("foo");
         }});
         
@@ -65,7 +65,7 @@ public class RecordingAcceptanceTests extends TestCase {
     }
     
     public void testReportsRecordedInvocationsWhenUnexpectedInvocationReceived() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWith("x");
             oneOf (mock).doSomethingWith("y");
         }});
@@ -85,7 +85,7 @@ public class RecordingAcceptanceTests extends TestCase {
     }
     
     public void testReportsRecordedInvocationsWhenNotSatisfied() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).doSomethingWith("x");
             oneOf (mock).doSomethingWith("y");
         }});

--- a/test/org/jmock/test/acceptance/RedeclaredObjectMethodsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/RedeclaredObjectMethodsAcceptanceTests.java
@@ -46,7 +46,7 @@ public class RedeclaredObjectMethodsAcceptanceTests extends TestCase {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         final Vector<Object> mock = (Vector<Object>)context.mock(Vector.class);
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             atLeast(1).of (mock).size(); will(returnValue(2));
         }});
         

--- a/test/org/jmock/test/acceptance/ReturningIteratorsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ReturningIteratorsAcceptanceTests.java
@@ -19,7 +19,7 @@ public class ReturningIteratorsAcceptanceTests extends TestCase {
     Iterators iterators = context.mock(Iterators.class);
     
     public void testReturnsIteratorsOverCollectionOfValues() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (iterators).i(); will(returnIterator("a", "b", "c"));
         }});
         
@@ -30,7 +30,7 @@ public class ReturningIteratorsAcceptanceTests extends TestCase {
     }
     
     public void testReturnsEnumerationsOverCollectionOfValues() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (iterators).e(); will(returnEnumeration("x", "y", "z"));
         }});
         

--- a/test/org/jmock/test/acceptance/ReturningValuesAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ReturningValuesAcceptanceTests.java
@@ -31,7 +31,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
         // ensure string is not interned
         final String result = new String("RESULT");
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing(mock).returnString();
             will(returnValue(result));
         }});
@@ -40,7 +40,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     }
 
     public void testCanReturnNullObjectReferences() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing(mock).returnString(); will(returnValue(null));
         }});
 
@@ -48,7 +48,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     }
 
     public void testCanReturnBooleanValues() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of(mock).returnBoolean(); will(returnValue(true));
             exactly(1).of(mock).returnBoolean(); will(returnValue(false));
         }});
@@ -60,7 +60,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     public void testCanReturnByteValues() {
         final byte result = 123;
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing(mock).returnByte(); will(returnValue(result));
         }});
 
@@ -70,7 +70,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     public void testCanReturnCharValues() {
         final char result = '\u1234';
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing(mock).returnChar(); will(returnValue(result));
         }});
 
@@ -80,7 +80,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     public void testCanReturnShortValues() {
         final short result = 12345;
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing(mock).returnShort(); will(returnValue(result));
         }});
 
@@ -90,7 +90,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     public void testCanReturnIntValues() {
         final int result = 1234567890;
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing(mock).returnInt(); will(returnValue(result));
         }});
 
@@ -100,7 +100,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     public void testCanReturnLongValues() {
         final long result = 1234567890124356789L;
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing(mock).returnLong(); will(returnValue(result));
         }});
 
@@ -110,7 +110,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     public void testCanReturnFloatValues() {
         final float result = 12345.67890f;
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing(mock).returnFloat(); will(returnValue(result));
         }});
 
@@ -120,7 +120,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     public void testCanReturnDoubleValues() {
         final double result = 1234567890.1234567890;
 
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).returnDouble(); will(returnValue(result));
         }});
 
@@ -128,7 +128,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     }
     
     public void testWillReturnADefaultValueIfNoResultExplicitlySpecified() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).returnInt();
         }});
         
@@ -145,7 +145,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     public void testReturnsNullAsTheDefaultValueForUnregisteredType() {
         final AnInterfaceThatReturnsSomething returningMock = context.mock(AnInterfaceThatReturnsSomething.class, "returningMock");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (returningMock).returnSomething();
         }});
         
@@ -161,7 +161,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
         
         context.setDefaultResultForType(Something.class, expectedDefaultResult);
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (returningMock).returnSomething();
         }});
         
@@ -174,7 +174,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
         String newDefaultString = "hoo-hee-haa-haa";
         context.setDefaultResultForType(String.class, newDefaultString);
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).returnString();
         }});
         
@@ -183,7 +183,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
 
     public void testReportsTypeMismatchOfResults() {
         try {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 allowing (mock).returnString(); will(returnValue(new Date()));
             }});
             
@@ -195,7 +195,7 @@ public class ReturningValuesAcceptanceTests extends TestCase {
     }
     
     public void testReportsTypeMismatchWhenValuesReturnedFromVoidMethods() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).voidMethod(); will(returnValue("wrong result"));
         }});
         

--- a/test/org/jmock/test/acceptance/SequenceAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/SequenceAcceptanceTests.java
@@ -16,7 +16,7 @@ public class SequenceAcceptanceTests extends TestCase {
     public void testCanConstrainInvocationsToOccurInOrder() {
         final Sequence s = context.sequence("s");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).method1(); inSequence(s);
             oneOf (mock).method2(); inSequence(s);
         }});
@@ -33,7 +33,7 @@ public class SequenceAcceptanceTests extends TestCase {
     public void testAllowsInvocationsInSequence() {
         final Sequence s = context.sequence("s");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).method1(); inSequence(s);
             oneOf (mock).method2(); inSequence(s);
         }});
@@ -45,7 +45,7 @@ public class SequenceAcceptanceTests extends TestCase {
     public void testCanSkipAllowedInvocationsInSequence() {
         final Sequence s = context.sequence("s");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).method1(); inSequence(s);
             allowing (mock).method2(); inSequence(s);
             oneOf (mock).method3(); inSequence(s);
@@ -59,7 +59,7 @@ public class SequenceAcceptanceTests extends TestCase {
         final Sequence s = context.sequence("s");
         final Sequence t = context.sequence("t");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).method1(); inSequence(s);
             oneOf (mock).method2(); inSequence(s);
             
@@ -76,7 +76,7 @@ public class SequenceAcceptanceTests extends TestCase {
     public void testExpectationIncludesSequenceInDescription() {
         final Sequence s = context.sequence("s");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).method1(); inSequence(s);
         }});
         
@@ -93,7 +93,7 @@ public class SequenceAcceptanceTests extends TestCase {
         final Sequence s = context.sequence("s");
         final Sequence t = context.sequence("t");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).method1(); inSequence(s);
             oneOf (mock).method2(); inSequence(t);
             oneOf (mock).method3(); inSequence(s); inSequence(t);
@@ -116,7 +116,7 @@ public class SequenceAcceptanceTests extends TestCase {
         final Sequence s = context.sequence("s");
         final Sequence t = context.sequence("t");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).method1(); inSequence(s);
             oneOf (mock).method2(); inSequence(t);
             oneOf (mock).method3(); inSequences(s, t);

--- a/test/org/jmock/test/acceptance/StatesAcceptanceTest.java
+++ b/test/org/jmock/test/acceptance/StatesAcceptanceTest.java
@@ -15,7 +15,7 @@ public class StatesAcceptanceTest extends TestCase {
     States readiness = context.states("readiness");
     
     public void testCanConstrainExpectationsToOccurWithinAGivenState() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).method1(); when(readiness.is("ready"));
             allowing (mock).doSomething(); then(readiness.is("ready"));
         }});
@@ -28,7 +28,7 @@ public class StatesAcceptanceTest extends TestCase {
     }
     
     public void testAllowsExpectationsToOccurInCorrectState() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).method1(); when(readiness.is("ready"));
             allowing (mock).doSomething(); then(readiness.is("ready"));
         }});
@@ -38,7 +38,7 @@ public class StatesAcceptanceTest extends TestCase {
     }
     
     public void testCanStartInASpecificState() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).method1(); when(readiness.is("ready"));
         }});
 
@@ -52,7 +52,7 @@ public class StatesAcceptanceTest extends TestCase {
         States fruitiness = context.states("fruitiness");
         fruitiness.startsAs("apple");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).method1(); when(readiness.is("ready"));
         }});
         
@@ -73,7 +73,7 @@ public class StatesAcceptanceTest extends TestCase {
         private static class TestException extends RuntimeException {}
     
     public void testSwitchesStateWhenMethodThrowsAnException() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (mock).method1(); will(throwException(new TestException())); 
                 then(readiness.is("ready"));
             oneOf (mock).method2(); when(readiness.is("ready"));

--- a/test/org/jmock/test/acceptance/ThrowingExceptionsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/ThrowingExceptionsAcceptanceTests.java
@@ -19,7 +19,7 @@ public class ThrowingExceptionsAcceptanceTests extends TestCase {
     Throwing mock = context.mock(Throwing.class, "mock");
     
     public void testCanThrowCheckedExceptions() throws Exception {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomething(); will(throwException(new CheckedException()));
         }});
         
@@ -33,7 +33,7 @@ public class ThrowingExceptionsAcceptanceTests extends TestCase {
     }
     
     public void testCanThrowUncheckedExceptions() throws Exception {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomething(); will(throwException(new UncheckedException()));
         }});
         
@@ -47,7 +47,7 @@ public class ThrowingExceptionsAcceptanceTests extends TestCase {
     }
     
     public void testCanThrowErrors() throws Exception {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomething(); will(throwException(new AnError()));
         }});
         
@@ -61,7 +61,7 @@ public class ThrowingExceptionsAcceptanceTests extends TestCase {
     }
     
     public void testCannotThrowUndeclaredCheckedExceptions() throws Exception {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             allowing (mock).doSomething(); will(throwException(new IncompatibleCheckedException()));
         }});
         

--- a/test/org/jmock/test/acceptance/UnorderedExpectationsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/UnorderedExpectationsAcceptanceTests.java
@@ -11,7 +11,7 @@ public class UnorderedExpectationsAcceptanceTests extends TestCase {
     MockedType mock = context.mock(MockedType.class, "mock");
     
     private void setUpUnorderedExpectations() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).method1();
             exactly(1).of (mock).method2();
             exactly(1).of (mock).method3();
@@ -91,7 +91,7 @@ public class UnorderedExpectationsAcceptanceTests extends TestCase {
     }
     
     public void testMatchesMethodsInFirstInFirstOutOrder() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             exactly(1).of (mock).returnString(); will(returnValue("1"));
             exactly(1).of (mock).returnString(); will(returnValue("2"));
             exactly(1).of (mock).returnString(); will(returnValue("3"));

--- a/test/org/jmock/test/acceptance/WarnAboutMultipleThreadsAcceptanceTests.java
+++ b/test/org/jmock/test/acceptance/WarnAboutMultipleThreadsAcceptanceTests.java
@@ -43,7 +43,7 @@ public class WarnAboutMultipleThreadsAcceptanceTests extends TestCase {
         
         final MockedType mock = mockery.mock(MockedType.class, "mock");
         
-        mockery.checking(new Expectations() {{
+        mockery.checking(new Expectations() {protected void expect() throws Exception{
             allowing (mock).doSomething();
         }});
         

--- a/test/org/jmock/test/acceptance/junit4/testdata/DerivedJUnit4TestThatDoesNotSatisfyExpectations.java
+++ b/test/org/jmock/test/acceptance/junit4/testdata/DerivedJUnit4TestThatDoesNotSatisfyExpectations.java
@@ -8,7 +8,7 @@ public class DerivedJUnit4TestThatDoesNotSatisfyExpectations extends BaseClassWi
     
     @Test
     public void doesNotSatisfyExpectations() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (runnable).run();
         }});
         

--- a/test/org/jmock/test/acceptance/junit4/testdata/JUnit4TestThatDoesNotSatisfyExpectations.java
+++ b/test/org/jmock/test/acceptance/junit4/testdata/JUnit4TestThatDoesNotSatisfyExpectations.java
@@ -14,7 +14,7 @@ public class JUnit4TestThatDoesNotSatisfyExpectations {
     
     @Test
     public void doesNotSatisfyExpectations() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (runnable).run();
         }});
         

--- a/test/org/jmock/test/acceptance/junit4/testdata/JUnit4TestThatDoesSatisfyExpectations.java
+++ b/test/org/jmock/test/acceptance/junit4/testdata/JUnit4TestThatDoesSatisfyExpectations.java
@@ -14,7 +14,7 @@ public class JUnit4TestThatDoesSatisfyExpectations {
     
     @Test
     public void doesSatisfyExpectations() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (runnable).run();
         }});
         

--- a/test/org/jmock/test/acceptance/junit4/testdata/JUnit4TestThatThrowsExpectedException.java
+++ b/test/org/jmock/test/acceptance/junit4/testdata/JUnit4TestThatThrowsExpectedException.java
@@ -14,7 +14,7 @@ public class JUnit4TestThatThrowsExpectedException {
     
     @Test(expected=CheckedException.class)
     public void doesNotSatisfyExpectationsWhenExpectedExceptionIsThrown() throws CheckedException {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception {
             oneOf (withException).anotherMethod();
             oneOf (withException).throwingMethod(); will(throwException(new CheckedException()));
         }});

--- a/test/org/jmock/test/acceptance/junit4/testdata/JUnit4WithRulesExamples.java
+++ b/test/org/jmock/test/acceptance/junit4/testdata/JUnit4WithRulesExamples.java
@@ -19,7 +19,7 @@ public class JUnit4WithRulesExamples {
         
         @Test
         public void doesSatisfyExpectations() {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 oneOf (runnable).run();
             }});
             
@@ -33,7 +33,7 @@ public class JUnit4WithRulesExamples {
         
         @Test
         public void doesNotSatisfyExpectations() {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 oneOf (runnable).run();
             }});
             
@@ -47,7 +47,7 @@ public class JUnit4WithRulesExamples {
         
         @Test
         public void doesNotSatisfyExpectations() {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 oneOf (runnable).run();
             }});
             
@@ -61,7 +61,7 @@ public class JUnit4WithRulesExamples {
         
         @Test(expected=CheckedException.class)
         public void doesNotSatisfyExpectationsWhenExpectedExceptionIsThrown() throws CheckedException {
-            context.checking(new Expectations() {{
+            context.checking(new Expectations() {protected void expect() throws Exception {
                 oneOf (withException).anotherMethod();
                 oneOf (withException).throwingMethod(); will(throwException(new CheckedException()));
             }});

--- a/test/org/jmock/test/unit/lib/concurrent/DeterministicExecutorTests.java
+++ b/test/org/jmock/test/unit/lib/concurrent/DeterministicExecutorTests.java
@@ -19,8 +19,8 @@ public class DeterministicExecutorTests extends MockObjectTestCase {
         scheduler.execute(commandB);
         
         final Sequence executionOrder = sequence("executionOrder");
-        
-        checking(new Expectations() {{
+
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run(); inSequence(executionOrder);
             oneOf (commandB).run(); inSequence(executionOrder);
         }});
@@ -34,7 +34,7 @@ public class DeterministicExecutorTests extends MockObjectTestCase {
         
         final Sequence executionOrder = sequence("executionOrder");
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run(); inSequence(executionOrder); will(schedule(commandC));
             oneOf (commandB).run(); inSequence(executionOrder); will(schedule(commandD));
             never (commandC).run();
@@ -50,7 +50,7 @@ public class DeterministicExecutorTests extends MockObjectTestCase {
         
         final Sequence executionOrder = sequence("executionOrder");
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run(); inSequence(executionOrder); will(schedule(commandC));
             oneOf (commandB).run(); inSequence(executionOrder); will(schedule(commandD));
             oneOf (commandC).run(); inSequence(executionOrder);

--- a/test/org/jmock/test/unit/lib/concurrent/DeterministicSchedulerTests.java
+++ b/test/org/jmock/test/unit/lib/concurrent/DeterministicSchedulerTests.java
@@ -35,7 +35,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
         
         final Sequence executionOrder = sequence("executionOrder");
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run(); inSequence(executionOrder);
             oneOf (commandB).run(); inSequence(executionOrder);
         }});
@@ -53,7 +53,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
         
         final Sequence executionOrder = sequence("executionOrder");
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run(); inSequence(executionOrder); will(schedule(commandC));
             oneOf (commandB).run(); inSequence(executionOrder); will(schedule(commandD));
             oneOf (commandC).run(); inSequence(executionOrder);
@@ -66,7 +66,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
     public void testCanScheduleCommandAndReturnFuture() throws InterruptedException, ExecutionException {
         Future<?> future = scheduler.submit(commandA);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run();
         }});
         
@@ -81,7 +81,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
     public void testCanScheduleCommandAndResultAndReturnFuture() throws InterruptedException, ExecutionException {
         Future<String> future = scheduler.submit(commandA, "result1");
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run();
         }});
        
@@ -93,7 +93,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
     public void testCanScheduleCallableAndReturnFuture() throws Exception {
         Future<String> future = scheduler.submit(callableA);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callableA).call(); will(returnValue("result2"));
         }});
         
@@ -103,7 +103,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
     }
 
     public void testScheduledCallablesCanReturnNull() throws Exception {
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callableA).call(); will(returnValue(null));
         }});
         
@@ -119,7 +119,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
     public void testExceptionThrownByScheduledCallablesIsThrownFromFuture() throws Exception {
         final Throwable thrown = new ExampleException();
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callableA).call(); will(throwException(thrown));
         }});
         
@@ -141,7 +141,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
         
         scheduler.tick(9, TimeUnit.SECONDS);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run();
         }});
         
@@ -152,7 +152,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
         scheduler.schedule(commandA, 1, TimeUnit.MILLISECONDS);
         scheduler.schedule(commandB, 2, TimeUnit.MILLISECONDS);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run();
             oneOf (commandB).run();
         }});
@@ -164,7 +164,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
         scheduler.schedule(commandA, 1, TimeUnit.MILLISECONDS);
         scheduler.schedule(commandD, 2, TimeUnit.MILLISECONDS);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (commandA).run(); will(schedule(commandB));
             oneOf (commandB).run(); will(schedule(commandC));
             oneOf (commandC).run();
@@ -177,7 +177,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
     public void testCanExecuteCommandsThatRepeatWithFixedDelay() {
         scheduler.scheduleWithFixedDelay(commandA, 2L, 3L, TimeUnit.SECONDS);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             exactly(3).of(commandA).run();
         }});
         
@@ -187,7 +187,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
     public void testCanExecuteCommandsThatRepeatAtFixedRateButAssumesThatCommandsTakeNoTimeToExecute() {
         scheduler.scheduleAtFixedRate(commandA, 2L, 3L, TimeUnit.SECONDS);
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             exactly(3).of(commandA).run();
         }});
         
@@ -202,7 +202,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
         future.cancel(dontCare);
         assertTrue(future.isCancelled());
         
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             never (commandA);
         }});
         
@@ -212,7 +212,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
     static final int TIMEOUT_IGNORED = 1000;
     
     public void testCanScheduleCallablesAndGetTheirResultAfterTheyHaveBeenExecuted() throws Exception {
-        checking(new Expectations() {{
+        checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callableA).call(); will(returnValue("A"));
         }});
         

--- a/test/org/jmock/test/unit/lib/concurrent/SynchroniserTests.java
+++ b/test/org/jmock/test/unit/lib/concurrent/SynchroniserTests.java
@@ -33,7 +33,7 @@ public class SynchroniserTests {
     
     @Test(timeout=250)
     public void allowsMultipleThreadsToCallMockObjects() throws InterruptedException {
-        mockery.checking(new Expectations() {{
+        mockery.checking(new Expectations() {protected void expect() throws Exception{
             exactly(blitzer.totalActionCount()).of(mockObject).action();
         }});
         
@@ -52,7 +52,7 @@ public class SynchroniserTests {
         
         final States threads = mockery.states("threads");
         
-        mockery.checking(new Expectations() {{
+        mockery.checking(new Expectations() {protected void expect() throws Exception{
             exactly(blitzer.totalActionCount()).of(mockObject).action();
                 when(threads.isNot("finished"));
                 
@@ -76,7 +76,7 @@ public class SynchroniserTests {
     public void canWaitForAStateMachineToEnterAGivenStateWithinSomeTimeout() throws InterruptedException {
         final States threads = mockery.states("threads");
         
-        mockery.checking(new Expectations() {{
+        mockery.checking(new Expectations() {protected void expect() throws Exception{
             exactly(blitzer.totalActionCount()).of(mockObject).action();
                 when(threads.isNot("finished"));
                 
@@ -138,7 +138,7 @@ public class SynchroniserTests {
     public void throwsExpectationErrorIfExpectationFailsWhileWaitingForStateMachineEvenIfWaitSucceeds() throws InterruptedException {
         final States threads = mockery.states("threads");
         
-        mockery.checking(new Expectations() {{
+        mockery.checking(new Expectations() {protected void expect() throws Exception{
             oneOf(mockObject).finished();
                 then(threads.is("finished"));
         }});

--- a/test/org/jmock/test/unit/lib/script/ScriptedActionTests.java
+++ b/test/org/jmock/test/unit/lib/script/ScriptedActionTests.java
@@ -29,7 +29,7 @@ public class ScriptedActionTests extends TestCase {
     
     
     public void testInterpretsCallbackExpression() throws Exception {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callout).doSomethingWith(callback); will(perform("$0.callback()"));
             oneOf (callback).callback();
         }});
@@ -40,7 +40,7 @@ public class ScriptedActionTests extends TestCase {
     }
 
     public void testScriptCanReferToParametersByIndex() {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callout).doSomethingWithBoth(callback, callback2); will(perform("$1.callback()"));
             oneOf (callback2).callback();
         }});
@@ -51,7 +51,7 @@ public class ScriptedActionTests extends TestCase {
     }
     
     public void testScriptCanReferToInvokedObjectAs$This() throws Exception {
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callout).doSomethingWith(callback); will(perform("$0.callbackWith($this)"));
             oneOf (callback).callbackWith(callout);
         }});
@@ -65,7 +65,7 @@ public class ScriptedActionTests extends TestCase {
         final Object v1 = new Object();
         final Object v2 = new Object();
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callout).doSomethingWith(callback); will(perform("$0.callbackWith(x, y)").where("x", v1).where("y", v2));
             oneOf (callback).callbackWith(v1, v2);
         }});
@@ -78,7 +78,7 @@ public class ScriptedActionTests extends TestCase {
     public void testExceptionThrownByCallbackIsPassedBackToCaller() throws Exception {
         final Exception exception = new Exception("exception");
         
-        context.checking(new Expectations() {{
+        context.checking(new Expectations() {protected void expect() throws Exception{
             oneOf (callout).doSomethingWith(callback); will(perform("$0.throwException()"));
             oneOf (callback).throwException(); will(throwException(exception));
         }});


### PR DESCRIPTION
http://jira.codehaus.org/browse/JMOCK-212

I fixed this issue, but back compatability was broken. Example of new test:

``` java
package org.jmock.test.acceptance.junit4.testdata;

import org.jmock.Expectations;
import org.junit.Test;

public class DerivedJUnit4TestThatDoesNotSatisfyExpectations extends BaseClassWithMockery {
    private Runnable runnable = context.mock(Runnable.class);

    @Test
    public void doesNotSatisfyExpectations() {
        context.checking(new Expectations() {
            protected void expect() throws Exception {
                oneOf(runnable).run();
            }
        });
        runnable.run();
    }
}
```
