### PR TITLE
ver: bump hamcrest libraries within intellij idea library config

### DIFF
--- a/.idea/libraries/hamcrest.xml
+++ b/.idea/libraries/hamcrest.xml
@@ -1,15 +1,15 @@
 <component name="libraryTable">
   <library name="hamcrest">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/lib/hamcrest-unit-test-1.3.0RC1.jar!/" />
-      <root url="jar://$PROJECT_DIR$/lib/hamcrest-core-1.3.0RC1.jar!/" />
-      <root url="jar://$PROJECT_DIR$/lib/hamcrest-library-1.3.0RC1.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/hamcrest-unit-test-1.3.0RC2.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/hamcrest-core-1.3.0RC2.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/hamcrest-library-1.3.0RC2.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/lib/hamcrest-unit-test-1.3.0RC1.jar!/" />
-      <root url="jar://$PROJECT_DIR$/lib/hamcrest-core-1.3.0RC1.jar!/" />
-      <root url="jar://$PROJECT_DIR$/lib/hamcrest-library-1.3.0RC1.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/hamcrest-unit-test-1.3.0RC2.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/hamcrest-core-1.3.0RC2.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/hamcrest-library-1.3.0RC2.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="DependencyValidationManager">
-    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
+  <component name="EntryPointsManager">
+    <entry_points version="2.0" />
   </component>
   <component name="JavadocGenerationManager">
     <option name="OUTPUT_DIRECTORY" />
@@ -22,6 +22,9 @@
   </component>
   <component name="ProjectDetails">
     <option name="projectName" value="jmock2" />
+  </component>
+  <component name="ProjectResources">
+    <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.6" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />

--- a/Jmock2.iml
+++ b/Jmock2.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/testdata" isTestSource="false" />


### PR DESCRIPTION
so that within intellij idea, the  module Jmock2 opens and builds from scratch.  Also sets jdk 1.6 within intellij  - is this a bad idea?  Don't pull this commit if you think it is.
