### PR TITLE
Putative fix for issues/15

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -18,7 +18,11 @@
       <entry name="?*.tld" />
       <entry name="?*.ftl" />
     </wildcardResourcePatterns>
-    <annotationProcessing enabled="false" useClasspath="true" />
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="false">
+        <processorPath useClasspath="true" />
+      </profile>
+    </annotationProcessing>
   </component>
 </project>
 

--- a/src/org/jmock/Mockery.java
+++ b/src/org/jmock/Mockery.java
@@ -125,7 +125,7 @@ public class Mockery implements SelfDescribing {
             throw new IllegalArgumentException("a mock with name " + name + " already exists");
         }
         
-        MockObject mock = new MockObject(typeToMock, name);
+        final MockObject mock = new MockObject(typeToMock, name);
         mockNames.add(name);
         
         Invokable invokable =

--- a/src/org/jmock/internal/ReturnDefaultValueAction.java
+++ b/src/org/jmock/internal/ReturnDefaultValueAction.java
@@ -2,35 +2,50 @@
  */
 package org.jmock.internal;
 
-import java.lang.reflect.Array;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.hamcrest.Description;
 import org.jmock.api.Action;
 import org.jmock.api.Imposteriser;
 import org.jmock.api.Invocation;
 import org.jmock.lib.JavaReflectionImposteriser;
 
+import java.beans.beancontext.BeanContextServicesSupport;
+import java.lang.reflect.Array;
+import java.util.*;
+
 
 /**
- * Returns a value of the invoked method's result type. Returns nothing from
- * void methods. Zero or false results are returned for primitive types. Arrays
- * and strings are returned with a length of zero. Types that can be
- * imposterised by the action's {@link Imposteriser} are returned as <a
- * href="http://www.c2.com/cgi/wiki?NullObject">Null Objects</a>. Otherwise
- * <code>null</code> is returned. The default value can be overridden for
- * specific types.
+ * Returns a default value for the invoked method's result type.
+ * <ul>
+ * <li>Returns nothing from void methods.</li>
+ * <li>Returns zero or false results for primitive types.</li>
+ * <li>Returns zero length instances for arrays and strings.</li>
+ * <li>Returns empty instances for collections and maps types in {@link java.util}.</li>
+ * <li></li>Returns imposterised <a
+ * href="http://www.c2.com/cgi/wiki?NullObject">Null Objects</a> for
+ * types that can be imposterised by the action's {@link Imposteriser}.</li>
+ * <li>Otherwise returns <code>null</code>.</li>
+ * The default value can be overridden for specific types.
  * 
- * @author nat
+ * @author Nat Pryce
+ * @author Steve Freeman 2013
  */
 public class ReturnDefaultValueAction implements Action {
-    private final Map<Class<?>, Object> resultValuesByType = new HashMap<Class<?>, Object>();
+    private final static Class<?>[] COLLECTION_MAP_TYPES = {
+      LinkedList.class,
+      TreeSet.class,
+      TreeMap.class,
+      BeanContextServicesSupport.class
+    };
+    private final Map<Class<?>, Object> resultValuesByType;
     private Imposteriser imposteriser;
 
-    public ReturnDefaultValueAction(Imposteriser imposteriser) {
+    public ReturnDefaultValueAction(Imposteriser imposteriser, Map<Class<?>, Object> typeToResultValue) {
         this.imposteriser = imposteriser;
-        createDefaultResults();
+        this.resultValuesByType = typeToResultValue;
+    }
+
+    public ReturnDefaultValueAction(Imposteriser imposteriser) {
+      this(imposteriser, createDefaultResults());
     }
 
     public ReturnDefaultValueAction() {
@@ -50,41 +65,63 @@ public class ReturnDefaultValueAction implements Action {
     }
 
     public Object invoke(Invocation invocation) throws Throwable {
-        Class<?> returnType = invocation.getInvokedMethod().getReturnType();
+      final Class<?> returnType = invocation.getInvokedMethod().getReturnType();
 
-        if (resultValuesByType.containsKey(returnType)) {
-            return resultValuesByType.get(returnType);
-        }
-        else if (returnType.isArray()) {
-            return Array.newInstance(returnType.getComponentType(), 0);
-        }
-        else if (imposteriser.canImposterise(returnType)) {
-            return imposteriser.imposterise(this, returnType);
-        }
-        else {
-            return null;
-        }
+      if (resultValuesByType.containsKey(returnType)) {
+          return resultValuesByType.get(returnType);
+      }
+      if (returnType.isArray()) {
+          return Array.newInstance(returnType.getComponentType(), 0);
+      }
+      if (isCollectionOrMap(returnType)) {
+        final Object instance = collectionOrMapInstanceFor(returnType);
+        if (instance != null) return instance;
+      }
+      if (imposteriser.canImposterise(returnType)) {
+          return imposteriser.imposterise(this, returnType);
+      }
+      return null;
     }
 
-    protected void createDefaultResults() {
-        addResult(boolean.class, Boolean.FALSE);
-        addResult(void.class, null);
-        addResult(byte.class, new Byte((byte)0));
-        addResult(short.class, new Short((short)0));
-        addResult(int.class, new Integer(0));
-        addResult(long.class, new Long(0L));
-        addResult(char.class, new Character('\0'));
-        addResult(float.class, new Float(0.0F));
-        addResult(double.class, new Double(0.0));
-        addResult(Boolean.class, Boolean.FALSE);
-        addResult(Byte.class, new Byte((byte)0));
-        addResult(Short.class, new Short((short)0));
-        addResult(Integer.class, new Integer(0));
-        addResult(Long.class, new Long(0L));
-        addResult(Character.class, new Character('\0'));
-        addResult(Float.class, new Float(0.0F));
-        addResult(Double.class, new Double(0.0));
-        addResult(String.class, "");
-        addResult(Object.class, new Object());
+    private Object collectionOrMapInstanceFor(Class<?> returnType) throws Throwable {
+      return returnType.isInterface() ? instanceForCollectionType(returnType) : returnType.newInstance();
+    }
+
+    private Object instanceForCollectionType(Class<?> type) throws Throwable {
+      for (Class<?> collectionType : COLLECTION_MAP_TYPES) {
+        if (type.isAssignableFrom(collectionType)) {
+          return collectionType.newInstance();
+        }
+      }
+      return null;
+    }
+
+    private boolean isCollectionOrMap(Class<?> type) {
+      return Collection.class.isAssignableFrom(type)
+          || Map.class.isAssignableFrom(type);
+    }
+
+    protected static Map<Class<?>, Object> createDefaultResults() {
+      final HashMap<Class<?>, Object> result = new HashMap<Class<?>, Object>();
+      result.put(boolean.class, Boolean.FALSE);
+      result.put(void.class, null);
+      result.put(byte.class, (byte) 0);
+      result.put(short.class, (short) 0);
+      result.put(int.class, 0);
+      result.put(long.class, 0L);
+      result.put(char.class, '\0');
+      result.put(float.class, 0.0F);
+      result.put(double.class, 0.0);
+      result.put(Boolean.class, Boolean.FALSE);
+      result.put(Byte.class, (byte) 0);
+      result.put(Short.class, (short) 0);
+      result.put(Integer.class, 0);
+      result.put(Long.class, 0L);
+      result.put(Character.class, '\0');
+      result.put(Float.class, 0.0F);
+      result.put(Double.class, 0.0);
+      result.put(String.class, "");
+      result.put(Object.class, new Object());
+      return result;
     }
 }

--- a/test/org/jmock/test/unit/internal/ReturnDefaultCollectionTests.java
+++ b/test/org/jmock/test/unit/internal/ReturnDefaultCollectionTests.java
@@ -1,0 +1,81 @@
+package org.jmock.test.unit.internal;
+
+import org.jmock.internal.ReturnDefaultValueAction;
+import org.junit.Test;
+
+import javax.xml.ws.handler.LogicalMessageContext;
+import java.beans.beancontext.BeanContext;
+import java.beans.beancontext.BeanContextServices;
+import java.beans.beancontext.BeanContextServicesSupport;
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.jmock.test.unit.internal.ReturnDefaultValueActionTests.invocationReturning;
+
+/**
+ * @author Steve Freeman 2013 http://www.jmock.org
+ * https://github.com/jmock-developers/jmock-library/issues/9
+ *
+ */
+public class ReturnDefaultCollectionTests {
+  private final ReturnDefaultValueAction action = new ReturnDefaultValueAction();
+
+  @SuppressWarnings("unchecked")
+  @Test public void
+  returnsANewInstanceForEachCall() throws Throwable {
+    final ArrayList firstInstance = returnedArrayList();
+    firstInstance.add(new Object());
+
+    assertThat(returnedArrayList(), is(empty()));
+  }
+
+  @Test public void
+  returnsNewInstanceOfIterableClasses() throws Throwable {
+    returnsInstanceForType(ArrayList.class, ArrayList.class);
+    returnsInstanceForType(PriorityQueue.class, PriorityQueue.class);
+  }
+
+  @Test public void
+  returnsNewInstanceOfMapClasses() throws Throwable {
+    returnsInstanceForType(HashMap.class, HashMap.class);
+    returnsInstanceForType(Properties.class, Properties.class);
+  }
+
+  @Test public void
+  returnsNewInstanceConformingToCollectionInterface() throws Throwable {
+    returnsInstanceForType(List.class, LinkedList.class);
+    returnsInstanceForType(Set.class, TreeSet.class);
+    returnsInstanceForType(NavigableSet.class, TreeSet.class);
+    returnsInstanceForType(SortedSet.class, TreeSet.class);
+    returnsInstanceForType(Queue.class, LinkedList.class);
+    returnsInstanceForType(Deque.class, LinkedList.class);
+    returnsInstanceForType(BeanContext.class, BeanContextServicesSupport.class);
+    returnsInstanceForType(BeanContextServices.class, BeanContextServicesSupport.class);
+  }
+
+  @Test public void
+  returnsNewInstanceConformingToMapType() throws Throwable {
+    returnsInstanceForType(Map.class, TreeMap.class);
+    returnsInstanceForType(SortedMap.class, TreeMap.class);
+    returnsInstanceForType(NavigableMap.class, TreeMap.class);
+  }
+
+  @Test public void
+  imposterisesUnsupportedMapTypes() throws Throwable {
+    assertThat(action.invoke(invocationReturning(LogicalMessageContext.class)).getClass(),
+               hasProperty("canonicalName", containsString("Proxy")));
+  }
+
+  private void returnsInstanceForType(Class<?> declaredType, Class<?> expectedType) throws Throwable {
+    assertThat(
+        action.invoke(invocationReturning(declaredType)),
+        instanceOf(expectedType));
+  }
+
+
+  private ArrayList returnedArrayList() throws Throwable {
+    return (ArrayList) action.invoke(invocationReturning(ArrayList.class));
+  }
+
+}


### PR DESCRIPTION
MethodMatcher can fail for restatement of generic method
Allow MethodMatcher to match some likely matching methods

I can't say I'm all that confident about this fix, but thought I'd open a dialog!
