### PR TITLE
Return Null as the default action for methods returning Abstract Collections

### DIFF
--- a/src/org/jmock/internal/ReturnDefaultValueAction.java
+++ b/src/org/jmock/internal/ReturnDefaultValueAction.java
@@ -9,6 +9,7 @@ import org.jmock.api.Invocation;
 import org.jmock.lib.JavaReflectionImposteriser;
 
 import java.lang.reflect.Array;
+import java.lang.reflect.Modifier;
 import java.util.*;
 
 
@@ -82,7 +83,7 @@ public class ReturnDefaultValueAction implements Action {
     }
 
     private Object collectionOrMapInstanceFor(Class<?> returnType) throws Throwable {
-      return returnType.isInterface() ? instanceForCollectionType(returnType) : returnType.newInstance();
+      return returnType.isInterface() || Modifier.isAbstract(returnType.getModifiers()) ? instanceForCollectionType(returnType) : returnType.newInstance();
     }
 
     private Object instanceForCollectionType(Class<?> type) throws Throwable {

--- a/test/org/jmock/test/unit/internal/AbstractCollection.java
+++ b/test/org/jmock/test/unit/internal/AbstractCollection.java
@@ -1,0 +1,7 @@
+package org.jmock.test.unit.internal;
+
+import java.util.Collection;
+
+abstract class AbstractCollection implements Collection {
+    
+}

--- a/test/org/jmock/test/unit/internal/ReturnDefaultCollectionTests.java
+++ b/test/org/jmock/test/unit/internal/ReturnDefaultCollectionTests.java
@@ -1,6 +1,8 @@
 package org.jmock.test.unit.internal;
 
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNull;
 import org.jmock.internal.ReturnDefaultValueAction;
 import org.junit.Test;
 
@@ -19,6 +21,7 @@ import static org.jmock.test.unit.internal.ReturnDefaultValueActionTests.invocat
  */
 public class ReturnDefaultCollectionTests {
     public static final Matcher<Object> IS_PROXY_CLASS = hasProperty("canonicalName", containsString("Proxy"));
+    public static final Matcher<Object> IS_NULL_VALUE = is(nullValue());
     private final ReturnDefaultValueAction action = new ReturnDefaultValueAction();
 
     @SuppressWarnings("unchecked")
@@ -69,6 +72,11 @@ public class ReturnDefaultCollectionTests {
     @Test public void
     imposterisesUnsupportedMapTypes() throws Throwable {
         assertThat(action.invoke(invocationReturning(LogicalMessageContext.class)).getClass(), IS_PROXY_CLASS);
+    }
+    
+    @Test public void
+    doesNotTryToInstantiateAbstractCollections() throws Throwable {
+        assertThat(action.invoke(invocationReturning(AbstractCollection.class)), IS_NULL_VALUE);
     }
 
     private void returnsInstanceForType(Class<?> declaredType, Class<?> expectedType) throws Throwable {


### PR DESCRIPTION
Added check to ReturnDefaultValueAction to avoid trying to instantiate abstract collection classes - fall back to null (as with other unsupported collections)
