### PR TITLE
Replaced @ characters not intended for javadoc with its html version.

### DIFF
--- a/src/org/jmock/integration/junit4/JUnitRuleMockery.java
+++ b/src/org/jmock/integration/junit4/JUnitRuleMockery.java
@@ -18,10 +18,10 @@ import static org.junit.Assert.fail;
  * have to specify <code>@RunWith(JMock.class)</code> any more). For example,  
  * 
  * <pre>public class ATestWithSatisfiedExpectations {
- *  @Rule public final JUnitRuleMockery context = new JUnitRuleMockery();
+ *  &#64;Rule public final JUnitRuleMockery context = new JUnitRuleMockery();
  *  private final Runnable runnable = context.mock(Runnable.class);
  *     
- *  @Test
+ *  &#64;Test
  *  public void doesSatisfyExpectations() {
  *    context.checking(new Expectations() {{
  *      oneOf (runnable).run();


### PR DESCRIPTION
Javadoc garbles most of the example in the JUnitRuleMockery.java javadoc. Using the html entity instead of @ makes the problem go away as expected. I believe this is the problem reported in issue #42.

Verified by using the 'ant javadoc'.
