### PR TITLE
close travis blitzer test issue #72

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ jdk:
   - oraclejdk7
   - openjdk6
 
+env:
+# Travis has slow VMs?
+- blitzerThreads=1 blitzerActions=1 blitzerTimeout=1000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
+[![Build Status](https://travis-ci.org/jmock-developers/jmock-library.svg?branch=jmock2)](https://travis-ci.org/jmock-developers/jmock-library)
+
+Upgrading to 2.8.X
+==================
+Are you seeing NPEs?
+  
+  We have had to make a breaking change to with(). Tests using with(any(matcher)) for method signatures that require native types will throw NullPointerException.
+  
+     oneOf(mock).methodWithIntParams(with(any(Integer.class)));
+  
+  should be changed to:
+
+    oneOf(mock).methodWithIntParams(with.intIs(anything());
+    
+  This is due to a compiler change in Java 1.7.
+  The 2.6.0 release was compiled with Java 1.6 so it did not suffer this problem.
+
 Advantages of jMock 2 over jMock 1
 ==================================
-
 * Uses real method calls, not strings: can refactor more easily and
   autocomplete in the IDE.
 * Customisation by delegation, not by inheritance

--- a/jmock/src/test/java/org/jmock/test/unit/lib/concurrent/BlitzerTests.java
+++ b/jmock/src/test/java/org/jmock/test/unit/lib/concurrent/BlitzerTests.java
@@ -3,17 +3,27 @@ package org.jmock.test.unit.lib.concurrent;
 import junit.framework.TestCase;
 import org.jmock.lib.concurrent.Blitzer;
 import org.junit.After;
+import org.junit.Before;
 
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.lang.System.getenv;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class BlitzerTests extends TestCase {
-    int threadCount = 3;
-    int actionCount = 12;
+    private static final String BLITZER_THREADS = "blitzerThreads";
+    private static final String BLITZER_ACTIONS = "blitzerActions";
+    private static final String BLITZER_TIMEOUT = "blitzerTimeout";
+    int threadCount = getIntEnvVar(BLITZER_THREADS, "3");
+    int actionCount = getIntEnvVar(BLITZER_ACTIONS, "12");
+    int timeout = getIntEnvVar(BLITZER_TIMEOUT, "100");
+
+    private int getIntEnvVar(String envVarName, String defaultValue) {
+        return Integer.parseInt(getenv().containsKey(envVarName) ? getenv(envVarName) : defaultValue);
+    }
 
     ThreadFactory quietThreadFactory = new ThreadFactory() {
         @Override
@@ -50,7 +60,7 @@ public class BlitzerTests extends TestCase {
     }
     
     public void testActionsCanFailWithoutDeadlockingTheTestThread() throws InterruptedException, TimeoutException {
-        blitzer.blitz(100, new Runnable() {
+        blitzer.blitz(timeout, new Runnable() {
             public void run() {
                 throw new RuntimeException("boom!");
             }


### PR DESCRIPTION
I've parameterised the blitzer concurrency and reduced it to a minimum for the travis build.
jdk6 and 7 were happy but jdk8 wasn't working in travis. As they're now parameters, we could in future, try and dial them up to something travis likes.