### PR TITLE
Make existing tests pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,129 @@
 [![Build Status](https://travis-ci.org/jmock-developers/jmock-library.svg?branch=jmock2)](https://travis-ci.org/jmock-developers/jmock-library)
 
+
 Upgrading to 2.8.X
 ==================
 Are you seeing NPEs?
-  
-  We have had to make a breaking change to with(). Tests using with(any(matcher)) for method signatures that require native types will throw NullPointerException.
-  
+
+We have had to make a breaking change to `with()`. Tests using `with(any(matcher))` for method signatures that require native types will throw `NullPointerException`.
+
+You should change
+
      oneOf(mock).methodWithIntParams(with(any(Integer.class)));
-  
-  should be changed to:
+
+to the following
 
     oneOf(mock).methodWithIntParams(with.intIs(anything());
-    
-  This is due to a compiler change in Java 1.7.
-  The 2.6.0 release was compiled with Java 1.6 so it did not suffer this problem.
+This is due to a compiler change in Java 1.7. The 2.6.0 release was compiled with Java 1.6 so it did not suffer this problem.
+
 
 Advantages of jMock 2 over jMock 1
 ==================================
-* Uses real method calls, not strings: can refactor more easily and
+* Uses real method calls, not strings, so you can refactor more easily and
   autocomplete in the IDE.
-* Customisation by delegation, not by inheritance
-* Many more plugin-points for customisation
+* Customisation by delegation, not by inheritance.
+* Many more plugin-points for customisation.
 * Independent of any testing framework: compatability with the testing
   framework is a plugin-point.
 * Can mock concrete classes *without* calling their constructors (if
   you really want to).
 * Uses Hamcrest matchers, so can use a large and ever-growing library
   of matchers in expectations.
-* Expectations match in FIFO order, so tests are easier to understand
+* Expectations match in first-in, first-out order, so tests are easier to understand.
+
 
 
 How to get up and running
 =========================
 
-You will need to add the jmock-2.0.0.jar and to your classpath.  Also
-add the appropriate integration JAR to your classpath to integrate
-jMock 2 with the test framework you use.  For example, if you use
-JUnit 4, add jmock-junit4-2.0.0.jar to your classpath.
+## Automatic Dependency Management
 
-You will also need to add hamcrest-api-1.0.0.jar and hamcrest-lib-1.0.0.jar
-to your classpath.
+If you're using Gradle or Maven (and perhaps Ant), then it suffices to add to your build file the "integration JAR" for the test library that you want to use. For example: `jmock-junit4-2.8.2`.
 
+For example, with Gradle:
+
+```
+testCompile(
+	"junit:junit:4.12",
+    "org.jmock:jmock-junit4:2.8.2"
+)
+```
+
+## Hand-Rolled Dependencies
+
+Add the `jmock-<version>.jar` to your classpath. (For example: `jmock-2.8.2.jar`.) Also add the integration JAR to your classpath for the test library ou're using. (For example: `jmock-junit4-2.8.2.jar`.) You also need `hamcrest-api-<version>.jar` and `hamcrest-lib-<version>.jar`.
 
 
 Package Structure
 =================
 
-jMock 2 is organised into published and internal packages.  We
-guarantee to maintain backward compatability of types in published
-packages within the same major version of jMock.  There are no
-guarantees about backward compatability for types in internal
-packages.
+[jMock]() 2 is organised into published and internal packages.  We guarantee backwards compatability of types in published packages within the same major version of jMock.  There are no guarantees about backward compatability for types in internal packages.
 
-Types defined in published packages may themselves define public
-methods that accept or return types from internal packages or inherit
-methods from types in internal packages.  Such methods have no
-compatability guarantees and should not be considered as part of the
-published interface.
+Types defined in published packages may themselves define public methods that accept or return types from internal packages or inherit methods from types in internal packages.  Such methods have no compatability guarantees and should not be considered as part of the published interface.
 
 
 Published packages
 ------------------
 
-org.jmock
-	DSL-style API
+### org.jmock
 
-org.jmock.api
+DSL-style API
 
-org.jmock.lib
-	Convenient classes that implement the APIs in the core, are used 
-	by the DSL-style API, and can be used in user-defined APIs 
+### org.jmock.api
 
-org.jmock.integration
-	Classes integrating jMock with different testing APIs, such 
-	as JUnit 3.x, JUnit 4.x and TestNG. 
+### org.jmock.lib
+
+Convenient classes that implement the APIs in the core, are used  by the DSL-style API, and can be used in user-defined APIs 
+
+### org.jmock.integration
+
+Classes integrating jMock with different testing APIs, such  as JUnit 3.x, JUnit 4.x and TestNG. 
 
 
 Packages of example code
 ------------------------
 
-org.jmock.lib.nonstd	
-	Lib classes that rely on clever hacks or otherwise cannot be 
-	guaranteed to always work in all JVMs.  There are no compatability
-	guarantees with these classes.  Use at your own risk.
+### org.jmock.lib.nonstd
+
+Lib classes that rely on clever hacks or otherwise cannot be  guaranteed to always work in all JVMs.  There are no compatability guarantees with these classes.  Use at your own risk.
 
 
 Internal packages
 -----------------
 
-org.jmock.internal
-	Internal implementation details 
+### org.jmock.internal
 
-org.jmock.test
-	Tests for jMock itself
+Internal implementation details 
 
+### org.jmock.test
+
+Tests for jMock itself
 
 
 Plug-in Points
 ==============
 
-Matcher:
-	Controls the matching of invocations to expectations
-Action:
-	Performs an action in response to an invocation
-Imposteriser:
-	Wraps mock objects in an adapter of the correct type
-Expectation:
-	Matches an invocation and fakes its behaviour
-ExpectationErrorTranslator: 
-	Translates expectation errors into error type used by a specific 
-	testing framework.
-MockObjectNamingScheme:
-    Creates names for mock objects based on the mocked type.
+### Matcher
+
+Controls the matching of invocations to expectations
+
+### Action
+
+Performs an action in response to an invocation
+
+### Imposteriser
+
+Wraps mock objects in an adapter of the correct type
+
+### Expectation
+
+Matches an invocation and fakes its behaviour
+
+### ExpectationErrorTranslator
+
+Translates expectation errors into error type used by a specific 
+testing framework.
+
+### MockObjectNamingScheme
+
+Creates names for mock objects based on the mocked type.

--- a/README.md
+++ b/README.md
@@ -127,3 +127,12 @@ testing framework.
 ### MockObjectNamingScheme
 
 Creates names for mock objects based on the mocked type.
+
+# Contributing
+
+If you'd like to contribute, then do the following:
+
+1.  clone this repository (`git clone …`)
+2.  install Maven (`brew install mvn` on Mac OS, for example)
+3.  `$ mvn package` in order to generate a signed JAR. This will run all the tests. (`$ mvn test` appears not to suffice.)
+

--- a/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
+++ b/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
@@ -2,61 +2,50 @@ package org.jmock.test.acceptance;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.api.ExpectationError;
 import org.junit.Test;
 
 public class PrimitiveParameterTypesAcceptanceTests {
-    public interface MethodsWithPrimitiveTypes {
-        void withBoolean(boolean b);
-        void withByte(byte b);
-        void withShort(short s);
-        void withInt(int i);
-        void withLong(long l);
-        void withFloat(float f);
-        void withDouble(double d);
-    }
-    
     public final Mockery context = new Mockery();
     private final MethodsWithPrimitiveTypes mock = context.mock(MethodsWithPrimitiveTypes.class, "mock");
 
     @Test
     public void canSetExpectationsWithMatchersForMethodsWithArgumentsOfPrimitiveTypes() {
         context.checking(new Expectations() {{
-            exactly(1).of (mock).withBoolean(with.booleanIs(equal(true)));
-            exactly(1).of (mock).withByte(with.byteIs(equal((byte)10)));
-            exactly(1).of (mock).withShort(with.shortIs(equal((short) 10)));
-            exactly(1).of (mock).withInt(with.intIs(equal(10)));
-            exactly(1).of (mock).withLong(with.longIs(equal(10L)));
-            exactly(1).of (mock).withFloat(with.floatIs(equal(10.0f)));
-            exactly(1).of (mock).withDouble(with.doubleIs(equal(10.0)));
+            exactly(1).of(mock).withBoolean(with.booleanIs(equal(true)));
+            exactly(1).of(mock).withByte(with.byteIs(equal((byte) 10)));
+            exactly(1).of(mock).withShort(with.shortIs(equal((short) 10)));
+            exactly(1).of(mock).withInt(with.intIs(equal(10)));
+            exactly(1).of(mock).withLong(with.longIs(equal(10L)));
+            exactly(1).of(mock).withFloat(with.floatIs(equal(10.0f)));
+            exactly(1).of(mock).withDouble(with.doubleIs(equal(10.0)));
         }});
-        
+
         mock.withBoolean(true);
-        mock.withByte((byte)10);
-        mock.withShort((short)10);
+        mock.withByte((byte) 10);
+        mock.withShort((short) 10);
         mock.withInt(10);
         mock.withLong(10L);
         mock.withFloat(10.0f);
         mock.withDouble(10.0);
-        
+
         context.assertIsSatisfied();
     }
 
     @Test
     public void canSetExpectationsWithLiteralsForMethodsWithArgumentsOfPrimitiveTypes() {
         context.checking(new Expectations() {{
-            exactly(1).of (mock).withBoolean(true);
-            exactly(1).of (mock).withByte((byte)10);
-            exactly(1).of (mock).withShort((short)10);
-            exactly(1).of (mock).withInt(10);
-            exactly(1).of (mock).withLong(10L);
-            exactly(1).of (mock).withFloat(10.0f);
-            exactly(1).of (mock).withDouble(10.0);
+            exactly(1).of(mock).withBoolean(true);
+            exactly(1).of(mock).withByte((byte) 10);
+            exactly(1).of(mock).withShort((short) 10);
+            exactly(1).of(mock).withInt(10);
+            exactly(1).of(mock).withLong(10L);
+            exactly(1).of(mock).withFloat(10.0f);
+            exactly(1).of(mock).withDouble(10.0);
         }});
-        
+
         mock.withBoolean(true);
-        mock.withByte((byte)10);
-        mock.withShort((short)10);
+        mock.withByte((byte) 10);
+        mock.withShort((short) 10);
         mock.withInt(10);
         mock.withLong(10L);
         mock.withFloat(10.0f);
@@ -64,33 +53,46 @@ public class PrimitiveParameterTypesAcceptanceTests {
 
         context.assertIsSatisfied();
     }
-    
+
     /**
      * Will fail unless ExpectationsCreator has added generic overloaded byte code
      */
     @Test
     public void testNonNullNativeIgnoringDocumentationParameterMatcher() {
         context.checking(new Expectations() {{
-            exactly(1).of (mock).withBoolean(with(any(Boolean.class)));
-            exactly(1).of (mock).withByte(with(any(Byte.class)));
-            exactly(1).of (mock).withShort(with(any(Short.class)));
-            exactly(1).of (mock).withInt(with(any(Integer.class)));
-            exactly(1).of (mock).withLong(with(any(Long.class)));
-            exactly(1).of (mock).withFloat(with(any(Float.class)));
-            exactly(1).of (mock).withDouble(with(any(Double.class)));
+            exactly(1).of(mock).withBoolean(with(any(Boolean.class)));
+            exactly(1).of(mock).withByte(with(any(Byte.class)));
+            exactly(1).of(mock).withShort(with(any(Short.class)));
+            exactly(1).of(mock).withInt(with(any(Integer.class)));
+            exactly(1).of(mock).withLong(with(any(Long.class)));
+            exactly(1).of(mock).withFloat(with(any(Float.class)));
+            exactly(1).of(mock).withDouble(with(any(Double.class)));
         }});
-        
+
         mock.withBoolean(true);
-        mock.withByte((byte)10);
-        mock.withShort((short)10);
+        mock.withByte((byte) 10);
+        mock.withShort((short) 10);
         mock.withInt(10);
         mock.withLong(10L);
         mock.withFloat(10.0f);
         mock.withDouble(10.0);
 
         context.assertIsSatisfied();
-
     }
 
+    public interface MethodsWithPrimitiveTypes {
+        void withBoolean(boolean b);
 
+        void withByte(byte b);
+
+        void withShort(short s);
+
+        void withInt(int i);
+
+        void withLong(long l);
+
+        void withFloat(float f);
+
+        void withDouble(double d);
+    }
 }

--- a/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
+++ b/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
@@ -72,10 +72,10 @@ public class PrimitiveParameterTypesAcceptanceTests {
         mock.withBoolean(true);
         mock.withByte((byte) 10);
         mock.withShort((short) 10);
-        mock.withInt(10);
-        mock.withLong(10L);
-        mock.withFloat(10.0f);
-        mock.withDouble(10.0);
+        mock.withInt((int) 10);
+        mock.withLong((long) 10);
+        mock.withFloat((float) 10.0);
+        mock.withDouble((double) 10.0);
 
         context.assertIsSatisfied();
     }

--- a/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
+++ b/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
@@ -1,8 +1,11 @@
 package org.jmock.test.acceptance;
 
+import org.jmock.AbstractExpectations;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.junit.Test;
+
+import static org.jmock.AbstractExpectations.anything;
 
 public class PrimitiveParameterTypesAcceptanceTests {
     public final Mockery context = new Mockery();
@@ -60,13 +63,13 @@ public class PrimitiveParameterTypesAcceptanceTests {
     @Test
     public void testNonNullNativeIgnoringDocumentationParameterMatcher() {
         context.checking(new Expectations() {{
-            exactly(1).of(mock).withBoolean(with(any(Boolean.class)));
-            exactly(1).of(mock).withByte(with(any(Byte.class)));
-            exactly(1).of(mock).withShort(with(any(Short.class)));
-            exactly(1).of(mock).withInt(with(any(Integer.class)));
-            exactly(1).of(mock).withLong(with(any(Long.class)));
-            exactly(1).of(mock).withFloat(with(any(Float.class)));
-            exactly(1).of(mock).withDouble(with(any(Double.class)));
+            exactly(1).of(mock).withBoolean(with.booleanIs(anything()));
+            exactly(1).of(mock).withByte(with.byteIs(anything()));
+            exactly(1).of(mock).withShort(with.shortIs(anything()));
+            exactly(1).of(mock).withInt(with.intIs(anything()));
+            exactly(1).of(mock).withLong(with.longIs(anything()));
+            exactly(1).of(mock).withFloat(with.floatIs(anything()));
+            exactly(1).of(mock).withDouble(with.doubleIs(anything()));
         }});
 
         mock.withBoolean(true);

--- a/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
+++ b/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
@@ -66,10 +66,10 @@ public class PrimitiveParameterTypesAcceptanceTests {
     }
     
     /**
-     * Will fail unless ExpecttionsCreator has added generic overloaded byte code
+     * Will fail unless ExpectationsCreator has added generic overloaded byte code
      */
     @Test
-    public void testNonNullNativeIgnoreingDocumentationParameterMatcher() {
+    public void testNonNullNativeIgnoringDocumentationParameterMatcher() {
         context.checking(new Expectations() {{
             exactly(1).of (mock).withBoolean(with(any(Boolean.class)));
             exactly(1).of (mock).withByte(with(any(Byte.class)));

--- a/jmock/src/test/java/org/jmock/test/unit/internal/FailingExampleTestCase.java
+++ b/jmock/src/test/java/org/jmock/test/unit/internal/FailingExampleTestCase.java
@@ -4,7 +4,7 @@ package org.jmock.test.unit.internal;
 /**
 * @author Steve Freeman 2012 http://www.jmock.org
 */
-public class FailingExampleTestCase extends VerifyingTestCase {
+public abstract class FailingExampleTestCase extends VerifyingTestCase {
     public static final Exception tearDownException = new Exception("tear down");
     public static final Exception testException = new Exception("test");
 

--- a/jmock/src/test/java/org/jmock/test/unit/internal/VerifyingTestCaseTests.java
+++ b/jmock/src/test/java/org/jmock/test/unit/internal/VerifyingTestCaseTests.java
@@ -78,7 +78,7 @@ public class VerifyingTestCaseTests extends TestCase {
 
   public void testThrowsTestExceptionRatherThanTearDownException() throws Throwable {
         try {
-            new FailingExampleTestCase("testThrowsExpectedException").runBare();
+            new FailingExampleTestCase("testThrowsExpectedException") {}.runBare();
             fail("should have thrown exception");
         } catch (Exception actual) {
             assertSame(FailingExampleTestCase.testException, actual);
@@ -87,7 +87,7 @@ public class VerifyingTestCaseTests extends TestCase {
 
     public void testThrowsTearDownExceptionWhenNoTestException() throws Throwable {
         try {
-            new FailingExampleTestCase("testDoesNotThrowException").runBare();
+            new FailingExampleTestCase("testDoesNotThrowException") {}.runBare();
             fail("should have thrown exception");
         } catch (Exception actual) {
             assertSame(FailingExampleTestCase.tearDownException, actual);


### PR DESCRIPTION
I made a few changes that I believe were needed in order for the existing tests to pass. This happened on MacOS 10.12 running JDK 1.8.0_112.