### PR TITLE
Fixed test to match the current documentation regarding primitives

### DIFF
--- a/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
+++ b/jmock/src/test/java/org/jmock/test/acceptance/PrimitiveParameterTypesAcceptanceTests.java
@@ -2,7 +2,6 @@ package org.jmock.test.acceptance;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.api.ExpectationError;
 import org.junit.Test;
 
 public class PrimitiveParameterTypesAcceptanceTests {
@@ -15,7 +14,7 @@ public class PrimitiveParameterTypesAcceptanceTests {
         void withFloat(float f);
         void withDouble(double d);
     }
-    
+
     public final Mockery context = new Mockery();
     private final MethodsWithPrimitiveTypes mock = context.mock(MethodsWithPrimitiveTypes.class, "mock");
 
@@ -71,15 +70,15 @@ public class PrimitiveParameterTypesAcceptanceTests {
     @Test
     public void testNonNullNativeIgnoreingDocumentationParameterMatcher() {
         context.checking(new Expectations() {{
-            exactly(1).of (mock).withBoolean(with(any(Boolean.class)));
-            exactly(1).of (mock).withByte(with(any(Byte.class)));
-            exactly(1).of (mock).withShort(with(any(Short.class)));
-            exactly(1).of (mock).withInt(with(any(Integer.class)));
-            exactly(1).of (mock).withLong(with(any(Long.class)));
-            exactly(1).of (mock).withFloat(with(any(Float.class)));
-            exactly(1).of (mock).withDouble(with(any(Double.class)));
+            exactly(1).of(mock).withBoolean(with.booleanIs(anything()));
+            exactly(1).of(mock).withByte(with.byteIs(anything()));
+            exactly(1).of(mock).withShort(with.shortIs(anything()));
+            exactly(1).of(mock).withInt(with.intIs(anything()));
+            exactly(1).of(mock).withLong(with.longIs(anything()));
+            exactly(1).of(mock).withFloat(with.floatIs(anything()));
+            exactly(1).of(mock).withDouble(with.doubleIs(anything()));
         }});
-        
+
         mock.withBoolean(true);
         mock.withByte((byte)10);
         mock.withShort((short)10);
@@ -89,8 +88,5 @@ public class PrimitiveParameterTypesAcceptanceTests {
         mock.withDouble(10.0);
 
         context.assertIsSatisfied();
-
     }
-
-
 }

--- a/jmock/src/test/java/org/jmock/test/unit/internal/FailingExampleTestCase.java
+++ b/jmock/src/test/java/org/jmock/test/unit/internal/FailingExampleTestCase.java
@@ -2,9 +2,12 @@ package org.jmock.test.unit.internal;
 
 
 /**
-* @author Steve Freeman 2012 http://www.jmock.org
-*/
-public class FailingExampleTestCase extends VerifyingTestCase {
+ * This class is not meant to run as a standalone test,
+ * but rather as input to other tests.
+ *
+ * @author Steve Freeman 2012 http://www.jmock.org
+ */
+public abstract class FailingExampleTestCase extends VerifyingTestCase {
     public static final Exception tearDownException = new Exception("tear down");
     public static final Exception testException = new Exception("test");
 
@@ -16,6 +19,7 @@ public class FailingExampleTestCase extends VerifyingTestCase {
         throw tearDownException;
 
     }
+
     public void testDoesNotThrowException() throws Exception {
         // no op
     }

--- a/jmock/src/test/java/org/jmock/test/unit/internal/VerifyingTestCaseTests.java
+++ b/jmock/src/test/java/org/jmock/test/unit/internal/VerifyingTestCaseTests.java
@@ -78,7 +78,7 @@ public class VerifyingTestCaseTests extends TestCase {
 
   public void testThrowsTestExceptionRatherThanTearDownException() throws Throwable {
         try {
-            new FailingExampleTestCase("testThrowsExpectedException").runBare();
+            new FailingExampleTestCase("testThrowsExpectedException") {}.runBare();
             fail("should have thrown exception");
         } catch (Exception actual) {
             assertSame(FailingExampleTestCase.testException, actual);
@@ -87,7 +87,7 @@ public class VerifyingTestCaseTests extends TestCase {
 
     public void testThrowsTearDownExceptionWhenNoTestException() throws Throwable {
         try {
-            new FailingExampleTestCase("testDoesNotThrowException").runBare();
+            new FailingExampleTestCase("testDoesNotThrowException") {}.runBare();
             fail("should have thrown exception");
         } catch (Exception actual) {
             assertSame(FailingExampleTestCase.tearDownException, actual);


### PR DESCRIPTION
The README as of 2016-12-19 mentioned a potential problem with primitives, any(), and `NullPointerException`s, so I think I fixed it.