### PR TITLE
Issue #104 Support adding expectations whilst other threads dispatch test invocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-
 language: java
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+dist: trusty
+
 language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
+  - openjdk7 #oracle not supported anymore 
+  # openjdk6 not supported any more
 
 env:
 # Travis has slow VMs?

--- a/jmock-example/pom.xml
+++ b/jmock-example/pom.xml
@@ -5,14 +5,14 @@
 
 	<groupId>org.jmock</groupId>
 	<artifactId>jmock-example</artifactId>
-	<version>2.8.3</version>
+	<version>2.8.4-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>jMock Examples</name>
 
 	<parent>
 		<groupId>org.jmock</groupId>
 		<artifactId>jmock-parent</artifactId>
-		<version>2.8.3</version>
+		<version>2.8.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jmock-junit3/pom.xml
+++ b/jmock-junit3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.8.3</version>
+        <version>2.8.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>jmock-junit3</artifactId>

--- a/jmock-junit4/pom.xml
+++ b/jmock-junit4/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.8.3</version>
+        <version>2.8.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jmock-legacy/pom.xml
+++ b/jmock-legacy/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.8.3</version>
+        <version>2.8.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jmock/pom.xml
+++ b/jmock/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.8.3</version>
+        <version>2.8.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jmock/src/main/java/org/jmock/Mockery.java
+++ b/jmock/src/main/java/org/jmock/Mockery.java
@@ -24,6 +24,7 @@ import java.util.Set;
  * 
  * @author npryce
  * @author smgf
+ * @author olibye
  * @author named by Ivan Moore.
  */
 public class Mockery implements SelfDescribing {
@@ -35,7 +36,7 @@ public class Mockery implements SelfDescribing {
     private final Set<String> mockNames = new HashSet<String>();
     private final ReturnDefaultValueAction defaultAction = new ReturnDefaultValueAction(imposteriser);
     private final List<Invocation> actualInvocations = new ArrayList<Invocation>();
-    private final InvocationDispatcher dispatcher = new InvocationDispatcher();
+    private final InvocationDispatcher dispatcher = threadingPolicy.buildDispatcher();
 
     private Error firstError = null;
 

--- a/jmock/src/main/java/org/jmock/Mockery.java
+++ b/jmock/src/main/java/org/jmock/Mockery.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 
 /**
@@ -36,7 +37,7 @@ public class Mockery implements SelfDescribing {
     private final Set<String> mockNames = new HashSet<String>();
     private final ReturnDefaultValueAction defaultAction = new ReturnDefaultValueAction(imposteriser);
     private final List<Invocation> actualInvocations = new ArrayList<Invocation>();
-    private final InvocationDispatcher dispatcher = threadingPolicy.buildDispatcher();
+    private final InvocationDispatcher dispatcher = new InvocationDispatcher(new CopyOnWriteArrayList(), new CopyOnWriteArrayList());
 
     private Error firstError = null;
 

--- a/jmock/src/main/java/org/jmock/api/ThreadingPolicy.java
+++ b/jmock/src/main/java/org/jmock/api/ThreadingPolicy.java
@@ -4,6 +4,4 @@ import org.jmock.internal.InvocationDispatcher;
 
 public interface ThreadingPolicy {
     Invokable synchroniseAccessTo(Invokable mockObject);
-
-    InvocationDispatcher buildDispatcher();
 }

--- a/jmock/src/main/java/org/jmock/api/ThreadingPolicy.java
+++ b/jmock/src/main/java/org/jmock/api/ThreadingPolicy.java
@@ -1,5 +1,9 @@
 package org.jmock.api;
 
+import org.jmock.internal.InvocationDispatcher;
+
 public interface ThreadingPolicy {
     Invokable synchroniseAccessTo(Invokable mockObject);
+
+    InvocationDispatcher buildDispatcher();
 }

--- a/jmock/src/main/java/org/jmock/internal/InvocationDispatcher.java
+++ b/jmock/src/main/java/org/jmock/internal/InvocationDispatcher.java
@@ -1,29 +1,39 @@
 package org.jmock.internal;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
 import org.hamcrest.Description;
 import org.hamcrest.SelfDescribing;
 import org.jmock.api.Expectation;
 import org.jmock.api.ExpectationError;
 import org.jmock.api.Invocation;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 public class InvocationDispatcher implements ExpectationCollector, SelfDescribing {
-	private List<Expectation> expectations = new ArrayList<Expectation>();
-	private List<StateMachine> stateMachines = new ArrayList<StateMachine>();
-    
+    private final Collection<Expectation> expectations;
+    private final Collection<StateMachine> stateMachines;
+
+    public InvocationDispatcher() {
+        expectations = new ArrayList<Expectation>();
+        stateMachines = new ArrayList<StateMachine>();
+    }
+
+    public InvocationDispatcher(Collection<Expectation> theExpectations, Collection<StateMachine> theStateMachines) {
+        expectations = theExpectations;
+        stateMachines = theStateMachines;
+    }
+
     public StateMachine newStateMachine(String name) {
         StateMachine stateMachine = new StateMachine(name);
         stateMachines.add(stateMachine);
         return stateMachine;
     }
-    
-	public void add(Expectation expectation) {
-		expectations.add(expectation);
-	}
-	
+
+    public void add(Expectation expectation) {
+        expectations.add(expectation);
+    }
+
     public void describeTo(Description description) {
         describe(description, expectations);
     }
@@ -32,12 +42,15 @@ public class InvocationDispatcher implements ExpectationCollector, SelfDescribin
         describe(description, describedWith(expectations, invocation));
     }
 
-    private Iterable<SelfDescribing> describedWith(List<Expectation> expectations, final Invocation invocation) {
+    private Iterable<SelfDescribing> describedWith(Iterable<Expectation> expectations, final Invocation invocation) {
         final Iterator<Expectation> iterator = expectations.iterator();
         return new Iterable<SelfDescribing>() {
             public Iterator<SelfDescribing> iterator() {
                 return new Iterator<SelfDescribing>() {
-                    public boolean hasNext() { return iterator.hasNext(); }
+                    public boolean hasNext() {
+                        return iterator.hasNext();
+                    }
+
                     public SelfDescribing next() {
                         return new SelfDescribing() {
                             public void describeTo(Description description) {
@@ -45,7 +58,10 @@ public class InvocationDispatcher implements ExpectationCollector, SelfDescribin
                             }
                         };
                     }
-                    public void remove() { iterator.remove(); }
+
+                    public void remove() {
+                        iterator.remove();
+                    }
                 };
             }
         };
@@ -53,36 +69,34 @@ public class InvocationDispatcher implements ExpectationCollector, SelfDescribin
 
     private void describe(Description description, Iterable<? extends SelfDescribing> selfDescribingExpectations) {
         if (expectations.isEmpty()) {
-            description.appendText("no expectations specified: did you...\n"+
-                                   " - forget to start an expectation with a cardinality clause?\n" +
-                                   " - call a mocked method to specify the parameter of an expectation?");
-        }
-        else {
+            description.appendText("no expectations specified: did you...\n" +
+                    " - forget to start an expectation with a cardinality clause?\n" +
+                    " - call a mocked method to specify the parameter of an expectation?");
+        } else {
             description.appendList("expectations:\n  ", "\n  ", "", selfDescribingExpectations);
             if (!stateMachines.isEmpty()) {
                 description.appendList("\nstates:\n  ", "\n  ", "", stateMachines);
             }
         }
     }
-    
 
     public boolean isSatisfied() {
-		for (Expectation expectation : expectations) {
-		    if (! expectation.isSatisfied()) {
+        for (Expectation expectation : expectations) {
+            if (!expectation.isSatisfied()) {
                 return false;
             }
         }
         return true;
-	}
-	
-	public Object dispatch(Invocation invocation) throws Throwable {
-		for (Expectation expectation : expectations) {
-		    if (expectation.matches(invocation)) {
-		        return expectation.invoke(invocation);
+    }
+
+    public Object dispatch(Invocation invocation) throws Throwable {
+        for (Expectation expectation : expectations) {
+            if (expectation.matches(invocation)) {
+                return expectation.invoke(invocation);
             }
         }
-        
+
         throw ExpectationError.unexpected("unexpected invocation", invocation);
-	}
+    }
 
 }

--- a/jmock/src/main/java/org/jmock/internal/SingleThreadedPolicy.java
+++ b/jmock/src/main/java/org/jmock/internal/SingleThreadedPolicy.java
@@ -34,4 +34,9 @@ public class SingleThreadedPolicy implements ThreadingPolicy {
         System.err.println(error);
         throw new ConcurrentModificationException(error);
     }
+
+    @Override
+    public InvocationDispatcher buildDispatcher() {
+        return new InvocationDispatcher();
+    }
 }

--- a/jmock/src/main/java/org/jmock/internal/SingleThreadedPolicy.java
+++ b/jmock/src/main/java/org/jmock/internal/SingleThreadedPolicy.java
@@ -34,9 +34,4 @@ public class SingleThreadedPolicy implements ThreadingPolicy {
         System.err.println(error);
         throw new ConcurrentModificationException(error);
     }
-
-    @Override
-    public InvocationDispatcher buildDispatcher() {
-        return new InvocationDispatcher();
-    }
 }

--- a/jmock/src/main/java/org/jmock/lib/concurrent/Synchroniser.java
+++ b/jmock/src/main/java/org/jmock/lib/concurrent/Synchroniser.java
@@ -95,10 +95,4 @@ public class Synchroniser implements ThreadingPolicy {
             }
         }
     }
-
-    @Override
-    public InvocationDispatcher buildDispatcher() {
-        // non blocking multi threaded strategy for this minor version upgrade
-        return new InvocationDispatcher(new CopyOnWriteArrayList(), new CopyOnWriteArrayList());
-    }
 }

--- a/jmock/src/main/java/org/jmock/lib/concurrent/Synchroniser.java
+++ b/jmock/src/main/java/org/jmock/lib/concurrent/Synchroniser.java
@@ -2,11 +2,13 @@ package org.jmock.lib.concurrent;
 
 import static org.hamcrest.StringDescription.asString;
 
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 
 import org.jmock.api.Invocation;
 import org.jmock.api.Invokable;
 import org.jmock.api.ThreadingPolicy;
+import org.jmock.internal.InvocationDispatcher;
 import org.jmock.internal.StatePredicate;
 import org.jmock.lib.concurrent.internal.FixedTimeout;
 import org.jmock.lib.concurrent.internal.InfiniteTimeout;
@@ -19,6 +21,7 @@ import org.junit.Assert;
  * helps tests synchronise with background threads.
  * 
  * @author Nat Pryce
+ * @author olibye
  */
 public class Synchroniser implements ThreadingPolicy {
     private final Object sync = new Object();
@@ -91,5 +94,11 @@ public class Synchroniser implements ThreadingPolicy {
                 sync.notifyAll();
             }
         }
+    }
+
+    @Override
+    public InvocationDispatcher buildDispatcher() {
+        // non blocking multi threaded strategy for this minor version upgrade
+        return new InvocationDispatcher(new CopyOnWriteArrayList(), new CopyOnWriteArrayList());
     }
 }

--- a/jmock/src/test/java/org/jmock/test/unit/internal/InvocationDispatcherTests.java
+++ b/jmock/src/test/java/org/jmock/test/unit/internal/InvocationDispatcherTests.java
@@ -1,61 +1,77 @@
 package org.jmock.test.unit.internal;
 
-import junit.framework.TestCase;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import org.jmock.api.Expectation;
 import org.jmock.api.ExpectationError;
 import org.jmock.api.Invocation;
 import org.jmock.internal.InvocationDispatcher;
+import org.jmock.internal.StateMachine;
 import org.jmock.test.unit.support.MethodFactory;
 import org.jmock.test.unit.support.MockExpectation;
 
+import junit.framework.TestCase;
+
 public class InvocationDispatcherTests extends TestCase {
-	MethodFactory methodFactory = new MethodFactory();
-	Invocation invocation = new Invocation(
-	    "invokedObject", 
-		methodFactory.newMethod("invokedMethod"),
-		Invocation.NO_PARAMETERS);
-	
-	static final boolean NOT_RELEVANT = true;
-	
+    
+    // Avoid multi threaeding tests deadlocking
+    // Adjust timeout for debugging
+    private static final TimeUnit TIMEOUT_UNIT = TimeUnit.SECONDS;
+    private static final int TIMEOUT = 2;
+    
+    MethodFactory methodFactory = new MethodFactory();
+    Invocation invocation = new Invocation(
+            "invokedObject",
+            methodFactory.newMethod("invokedMethod"),
+            Invocation.NO_PARAMETERS);
+
+    static final boolean NOT_RELEVANT = true;
+
     public void testInvokesFirstMatchingExpectationInGroup() throws Throwable {
         MockExpectation expectation1 = new MockExpectation(false, NOT_RELEVANT, NOT_RELEVANT);
         MockExpectation expectation2 = new MockExpectation(true, NOT_RELEVANT, NOT_RELEVANT);
         MockExpectation expectation3 = new MockExpectation(true, NOT_RELEVANT, NOT_RELEVANT);
-        
+
         InvocationDispatcher dispatcher = new InvocationDispatcher();
         dispatcher.add(expectation1);
         dispatcher.add(expectation2);
         dispatcher.add(expectation3);
-        
+
         expectation1.shouldNotBeInvoked();
         expectation2.shouldBeInvokedWith(invocation);
         expectation3.shouldNotBeInvoked();
-        
+
         dispatcher.dispatch(invocation);
-        
-        assertTrue("expectation2 should have been invoked", 
-                   expectation2.wasInvoked);
+
+        assertTrue("expectation2 should have been invoked",
+                expectation2.wasInvoked);
     }
 
     public void testThrowsExpectationErrorIfNoExpectationsMatchAnInvocation() throws Throwable {
         MockExpectation expectation1 = new MockExpectation(false, NOT_RELEVANT, NOT_RELEVANT);
         MockExpectation expectation2 = new MockExpectation(false, NOT_RELEVANT, NOT_RELEVANT);
         MockExpectation expectation3 = new MockExpectation(false, NOT_RELEVANT, NOT_RELEVANT);
-        
+
         InvocationDispatcher dispatcher = new InvocationDispatcher();
         dispatcher.add(expectation1);
         dispatcher.add(expectation2);
         dispatcher.add(expectation3);
-        
+
         expectation1.shouldNotBeInvoked();
         expectation2.shouldNotBeInvoked();
         expectation3.shouldNotBeInvoked();
-        
+
         try {
             dispatcher.dispatch(invocation);
             fail("should have thrown ExpectationError");
-        }
-        catch (ExpectationError e) {
+        } catch (ExpectationError e) {
             // expected
         }
     }
@@ -65,24 +81,166 @@ public class InvocationDispatcherTests extends TestCase {
         dispatcherAll.add(new MockExpectation(NOT_RELEVANT, true, NOT_RELEVANT));
         dispatcherAll.add(new MockExpectation(NOT_RELEVANT, true, NOT_RELEVANT));
         assertTrue("should be satisfied if all expectations are satisfied",
-                   dispatcherAll.isSatisfied());
-        
+                dispatcherAll.isSatisfied());
+
         InvocationDispatcher dispatcher1 = new InvocationDispatcher();
         dispatcher1.add(new MockExpectation(NOT_RELEVANT, true, NOT_RELEVANT));
         dispatcher1.add(new MockExpectation(NOT_RELEVANT, false, NOT_RELEVANT));
         assertFalse("should not be satisfied if first expectation is not satisfied",
-                   dispatcher1.isSatisfied());
-        
+                dispatcher1.isSatisfied());
+
         InvocationDispatcher dispatcher2 = new InvocationDispatcher();
         dispatcher2.add(new MockExpectation(NOT_RELEVANT, false, NOT_RELEVANT));
         dispatcher2.add(new MockExpectation(NOT_RELEVANT, true, NOT_RELEVANT));
         assertFalse("should not be satisfied if second expectation is not satisfied",
-                   dispatcher2.isSatisfied());
-        
+                dispatcher2.isSatisfied());
+
         InvocationDispatcher dispatcherNone = new InvocationDispatcher();
         dispatcherNone.add(new MockExpectation(NOT_RELEVANT, false, NOT_RELEVANT));
         dispatcherNone.add(new MockExpectation(NOT_RELEVANT, true, NOT_RELEVANT));
         assertFalse("should not be satisfied if no expectations are satisfied",
-                    dispatcherNone.isSatisfied());
+                dispatcherNone.isSatisfied());
     }
+
+    /**
+     * Resolves issue 104
+     * 
+     * @throws Throwable
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testHandlesAddingExpectationsWhileOtherTestsDispatch() throws Throwable {
+
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        MockExpectation expectation1 = new MockExpectation(true, NOT_RELEVANT, NOT_RELEVANT);
+        MockExpectation expectation2 = new MockExpectation(false, NOT_RELEVANT, NOT_RELEVANT);
+
+        CriticalSectionForcingCollectionWrapper<Expectation> expectations = new CriticalSectionForcingCollectionWrapper(
+                new CopyOnWriteArrayList(), barrier);
+        CriticalSectionForcingCollectionWrapper<StateMachine> stateMachines = new CriticalSectionForcingCollectionWrapper(
+                new ArrayList(), barrier);
+        final InvocationDispatcher dispatcher = new InvocationDispatcher(expectations, stateMachines);
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    barrier.await(TIMEOUT, TIMEOUT_UNIT);
+                    barrier.await(TIMEOUT, TIMEOUT_UNIT);
+                    // now the expectation one has been added
+                    
+                    dispatcher.dispatch(invocation);
+                    barrier.await(TIMEOUT, TIMEOUT_UNIT);
+                } catch (Throwable e) {
+                    // will throw a ConcurrentModification Exception unless a multithreaded strategy
+                    // is used
+                    throw new RuntimeException(e);
+                }
+            }
+        }, "Concurrent Dispatch").start();
+
+        // expect dispatch
+        dispatcher.add(expectation1);
+        // await is satisfied check
+
+        dispatcher.add(expectation2);
+        barrier.await(TIMEOUT, TIMEOUT_UNIT);
+
+        expectation1.shouldBeInvokedWith(invocation);
+        assertTrue("expectation1 should have been invoked",
+                expectation1.wasInvoked);
+    }
+
+    private class CriticalSectionForcingCollectionWrapper<T> implements Collection<T> {
+        private final Collection<T> delegate;
+        private final CyclicBarrier barrier;
+
+        CriticalSectionForcingCollectionWrapper(Collection<T> delegate, CyclicBarrier barrier) {
+            this.delegate = delegate;
+            this.barrier = barrier;
+        }
+
+        private void await() {
+            try {
+                // we want the expectation check to have got the iterator
+                // but not progressed checking
+                barrier.await(TIMEOUT, TIMEOUT_UNIT);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } catch (BrokenBarrierException e) {
+                throw new RuntimeException(e);
+            } catch (TimeoutException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public int size() {
+            return delegate.size();
+        }
+
+        public boolean isEmpty() {
+            return delegate.isEmpty();
+        }
+
+        public boolean contains(Object o) {
+            return delegate.contains(o);
+        }
+
+        public Iterator<T> iterator() {
+            Iterator<T> reply = delegate.iterator();
+            await(); // expectation add follows this
+            await(); // wait for add to complete
+            return reply;
+        }
+
+        public Object[] toArray() {
+            return delegate.toArray();
+        }
+
+        public <T> T[] toArray(T[] a) {
+            return delegate.toArray(a);
+        }
+
+        public boolean add(T e) {
+            // Make sure iterator is called before adding
+            await();
+            boolean reply = delegate.add(e);
+            // Make sure iterator returns after adding
+            await();
+            return reply;
+        }
+
+        public boolean remove(Object o) {
+            return delegate.remove(o);
+        }
+
+        public boolean containsAll(Collection<?> c) {
+            return delegate.containsAll(c);
+        }
+
+        public boolean addAll(Collection<? extends T> c) {
+            return delegate.addAll(c);
+        }
+
+        public boolean removeAll(Collection<?> c) {
+            return delegate.removeAll(c);
+        }
+
+        public boolean retainAll(Collection<?> c) {
+            return delegate.retainAll(c);
+        }
+
+        public void clear() {
+            delegate.clear();
+        }
+
+        public boolean equals(Object o) {
+            return delegate.equals(o);
+        }
+
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,11 @@
 
     <groupId>org.jmock</groupId>
     <artifactId>jmock-parent</artifactId>
-    <version>2.8.3</version>
+    <version>2.8.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>jMock 2 Parent</name>
 
-    <!-- mvn versions:set -DoldVersion=2.8.3-SNAPSHOT -DnewVersion=2.8.3 
-        -DgroupId=org.jmock -->
+    <!-- mvn versions:set -DoldVersion=2.8.3 -DnewVersion=2.8.4-SNAPSHOT -DgroupId=org.jmock -->
     <!-- find . -name pom.xml.versionsBackup -exec rm {} \; -->
 
     <parent>
@@ -205,6 +204,25 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+    
+    <reporting>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.5</version>
+          <reportSets>
+            <reportSet>
+              <reports>
+                <report>dependency-updates-report</report>
+                <report>plugin-updates-report</report>
+                <report>property-updates-report</report>
+              </reports>
+            </reportSet>
+          </reportSets>
+        </plugin>
+      </plugins>
+    </reporting>
 
     <profiles>
         <profile>

--- a/testjar/pom.xml
+++ b/testjar/pom.xml
@@ -58,7 +58,7 @@
 							<goal>sign</goal>
 						</goals>
 						<configuration>
-							<keyname>Not Oli Bye</keyname>
+							<keyname>899FD4CB</keyname>
 							<secretKeyring>${basedir}/secring.gpg</secretKeyring>
 							<publicKeyring>${basedir}/pubring.gpg</publicKeyring>
 							<passphrase>secret</passphrase>

--- a/testjar/pom.xml
+++ b/testjar/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.jmock</groupId>
 		<artifactId>jmock-parent</artifactId>
-		<version>2.8.3</version>
+		<version>2.8.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -58,7 +58,7 @@
 							<goal>sign</goal>
 						</goals>
 						<configuration>
-							<keyname>899FD4CB</keyname>
+							<keyname>Not Oli Bye</keyname>
 							<secretKeyring>${basedir}/secring.gpg</secretKeyring>
 							<publicKeyring>${basedir}/pubring.gpg</publicKeyring>
 							<passphrase>secret</passphrase>


### PR DESCRIPTION
This is a Non blocking, Non API breaking change to target 2.8.4.
We also have to drop the build for openJDK6 as travis no longer supports it.

There will be a follow up 2.9.0 Which delegates the building of the InvocationDispatcher to the Threading Policy.

This will allow me to add a BlockingInvocationDispatcher ThreadingPolicy that uses synchronisation instead of CopyOnWriteArrayLists where CopyOnWrite is too expensive (e.g. many expectations).

The choice will then be back to the Test writer, and there will be 3 ThreadingPolicies.