### PR TITLE
Test failure with Java 11 caused by the removal of JAX-WS

### DIFF
--- a/jmock/pom.xml
+++ b/jmock/pom.xml
@@ -43,6 +43,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <version>2.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Hi,

JAX-WS is no longer part of Java 11 and this causes an error in ReturnDefaultCollectionTests:

```
Tests run: 8, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.084 sec <<< FAILURE! - in org.jmock.test.unit.internal.ReturnDefaultCollectionTests
imposterisesUnsupportedMapTypes(org.jmock.test.unit.internal.ReturnDefaultCollectionTests)  Time elapsed: 0.002 sec  <<< ERROR!
java.lang.NoClassDefFoundError: javax/xml/ws/handler/LogicalMessageContext
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:582)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:190)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:499)
        at org.jmock.test.unit.internal.ReturnDefaultCollectionTests.imposterisesUnsupportedMapTypes(ReturnDefaultCollectionTests.java:72)
```

Adding an explicit test dependency on jaxws-api fixes this.