### PR TITLE
Jdk 9 10 11 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ hamcrest-test-src
 .project
 .classpath
 .gradle
+.factorypath
 gradle
 *.iml
 *.ipr

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: java
 
 jdk:
-# net.sf.cglib.core.DuplicatesPredicate$UnnecessaryBridgeFinder does not like org.objectweb.asm.ClassReader nestMembersOffset > 0 for JDK11 classes
 #  - openjdk-ea
-#  - openjdk11
+  - openjdk11
 #  - oraclejdk11
   - openjdk10
-  - oraclejdk10
+#  - oraclejdk10
   - openjdk9
   - oraclejdk8
-  - openjdk7 #oracle not supported anymore 
-  # openjdk6 not supported any more
+#  - openjdk7 #oracle not supported anymore 
+#  - openjdk6 not supported any more
 
 env:
 # Travis has slow VMs?

--- a/README.DEVELOPMENT
+++ b/README.DEVELOPMENT
@@ -39,9 +39,12 @@ result of the wrong type.
 
 Release
 =======
-mvn versions:set -DoldVersion=2.8.1-SNAPSHOT -DnewVersion=2.8.1 -DgroupId=org.jmock -DgenerateBackupPoms=false
+mvn versions:set -DoldVersion=* -DnewVersion=2.10.0 -DgroupId=org.jmock -DgenerateBackupPoms=false
 
 eval $(gpg-agent --daemon --no-grab --write-env-file $HOME/.gpg-agent-info)
 export GPG_AGENT_INFO
 export GPG_TTY=$(tty)
 mvn clean deploy -P release --settings settings.xml -Dgpg.keyname=XXXXXXXX
+
+mvn versions:set -DoldVersion=* -DnewVersion=2.11.0-SNAPSHOT -DgroupId=org.jmock -DgenerateBackupPoms=false
+

--- a/README.DEVELOPMENT
+++ b/README.DEVELOPMENT
@@ -39,8 +39,7 @@ result of the wrong type.
 
 Release
 =======
-mvn versions:set -DoldVersion=2.8.1-SNAPSHOT -DnewVersion=2.8.1 -DgroupId=org.jmock
-find . -name pom.xml.versionsBackup -exec rm {} \;
+mvn versions:set -DoldVersion=2.8.1-SNAPSHOT -DnewVersion=2.8.1 -DgroupId=org.jmock -DgenerateBackupPoms=false
 
 eval $(gpg-agent --daemon --no-grab --write-env-file $HOME/.gpg-agent-info)
 export GPG_AGENT_INFO

--- a/jmock-example/pom.xml
+++ b/jmock-example/pom.xml
@@ -5,14 +5,14 @@
 
 	<groupId>org.jmock</groupId>
 	<artifactId>jmock-example</artifactId>
-	<version>2.9.0</version>
+	<version>2.10.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>jMock Examples</name>
 
 	<parent>
 		<groupId>org.jmock</groupId>
 		<artifactId>jmock-parent</artifactId>
-		<version>2.9.0</version>
+		<version>2.10.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jmock-example/pom.xml
+++ b/jmock-example/pom.xml
@@ -5,14 +5,14 @@
 
 	<groupId>org.jmock</groupId>
 	<artifactId>jmock-example</artifactId>
-	<version>2.9.0-SNAPSHOT</version>
+	<version>2.9.0</version>
 	<packaging>jar</packaging>
 	<name>jMock Examples</name>
 
 	<parent>
 		<groupId>org.jmock</groupId>
 		<artifactId>jmock-parent</artifactId>
-		<version>2.9.0-SNAPSHOT</version>
+		<version>2.9.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jmock-imposters/pom.xml
+++ b/jmock-imposters/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.jmock</groupId>
+        <artifactId>jmock-parent</artifactId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>jmock-imposters</artifactId>
+    <description>Class mocks are more numerous than interface mocks, so drop the legacy name</description>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.jmock</groupId>
+            <artifactId>jmock</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/jmock-imposters/src/main/java/org/jmock/lib/imposters/ByteBuddyClassImposteriser.java
+++ b/jmock-imposters/src/main/java/org/jmock/lib/imposters/ByteBuddyClassImposteriser.java
@@ -1,0 +1,144 @@
+package org.jmock.lib.imposters;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Random;
+
+import org.jmock.api.Imposteriser;
+import org.jmock.api.Invocation;
+import org.jmock.api.Invokable;
+import org.jmock.internal.SearchingClassLoader;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.NamingStrategy;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+import net.bytebuddy.dynamic.loading.ClassInjector;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.InvocationHandlerAdapter;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * This class lets you imposterise abstract and concrete classes
+ * <em>without</em> calling the constructors of the mocked class.
+ * 
+ * @author olibye
+ */
+public class ByteBuddyClassImposteriser implements Imposteriser {
+
+    private static final String MOCK_TYPE_SUFFIX = "JMock";
+    public static final Imposteriser INSTANCE = new ByteBuddyClassImposteriser();
+
+    private final Random random = new Random();
+    private final Objenesis objenesis = new ObjenesisStd();
+
+    private ByteBuddyClassImposteriser() {
+    }
+
+    public boolean canImposterise(Class<?> type) {
+        return !type.isPrimitive() &&
+                !Modifier.isFinal(type.getModifiers()) &&
+                (type.isInterface() || !toStringMethodIsFinal(type));
+    }
+
+    public <T> T imposterise(final Invokable mockObject, Class<T> mockedType, Class<?>... ancilliaryTypes) {
+        if (!mockedType.isInterface() && toStringMethodIsFinal(mockedType)) {
+            throw new IllegalArgumentException(mockedType.getName() + " has a final toString method");
+        }
+
+        try {
+            setConstructorsAccessible(mockedType, true);
+            return mockedType.cast(proxy(mockObject, mockedType, ancilliaryTypes));
+        } finally {
+            setConstructorsAccessible(mockedType, false);
+        }
+    }
+
+    private boolean toStringMethodIsFinal(Class<?> type) {
+        try {
+            Method toString = type.getMethod("toString");
+            return Modifier.isFinal(toString.getModifiers());
+
+        } catch (SecurityException e) {
+            throw new IllegalStateException("not allowed to reflect on toString method", e);
+        } catch (NoSuchMethodException e) {
+            throw new Error("no public toString method found", e);
+        }
+    }
+
+    private void setConstructorsAccessible(Class<?> mockedType, boolean accessible) {
+        for (Constructor<?> constructor : mockedType.getDeclaredConstructors()) {
+            constructor.setAccessible(accessible);
+        }
+    }
+
+    private Object proxy(final Invokable mockObject, final Class<?> mockedType, Class<?>... ancilliaryTypes) {
+
+        Builder<?> builder = new ByteBuddy()
+                .with(namingStrategy(mockedType))
+                .subclass(mockedType)
+                .implement(ancilliaryTypes)
+                .method(ElementMatchers.any())
+                .intercept(InvocationHandlerAdapter.of(new InvocationHandler() {
+                    public Object invoke(Object receiver, Method method, Object[] args) throws Throwable {
+                        return mockObject.invoke(new Invocation(receiver, method, args));
+                    }
+                }));
+
+        // From
+        // https://mydailyjava.blogspot.com/2018/04/jdk-11-and-proxies-in-world-past.html
+        try {
+            ClassLoadingStrategy<ClassLoader> strategy;
+            if (ClassInjector.UsingLookup.isAvailable() && !protectedPackageNameSpaces(mockedType)
+                    && !defaultPackage(mockedType)) {
+                Class<?> methodHandles = Class.forName("java.lang.invoke.MethodHandles");
+                Object lookup = methodHandles.getMethod("lookup").invoke(null);
+                Method privateLookupIn = methodHandles.getMethod("privateLookupIn",
+                        Class.class,
+                        Class.forName("java.lang.invoke.MethodHandles$Lookup"));
+                Object privateLookup = privateLookupIn.invoke(null, mockedType, lookup);
+                strategy = ClassLoadingStrategy.UsingLookup.of(privateLookup);
+            } else if (ClassInjector.UsingReflection.isAvailable()) {
+                strategy = ClassLoadingStrategy.Default.INJECTION;
+            } else {
+                throw new IllegalStateException("No code generation strategy available");
+            }
+
+            return objenesis.newInstance(builder.make()
+                    .load(SearchingClassLoader.combineLoadersOf(mockedType, ancilliaryTypes), strategy)
+                    .getLoaded());
+
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+                | SecurityException | ClassNotFoundException e) {
+            throw new RuntimeException("Exception in code generation strategy available", e);
+        }
+    }
+
+    private boolean defaultPackage(Class<?> mockedType) {
+        return mockedType.getPackage().getName().isEmpty();
+    }
+
+    private NamingStrategy namingStrategy(Class<?> mockedType) {
+        if (protectedPackageNameSpaces(mockedType)) {
+            return new NamingStrategy.SuffixingRandom(MOCK_TYPE_SUFFIX);
+        }
+        return new NamingStrategy.AbstractBase() {
+            @Override
+            protected String name(TypeDescription superClass) {
+                String possiblePackageName = superClass.getPackage().getName();
+                String validPackageName = possiblePackageName.isEmpty() ? "" : possiblePackageName + ".";
+                return validPackageName + superClass.getSimpleName() + MOCK_TYPE_SUFFIX
+                        + random.nextInt(Integer.MAX_VALUE);
+            }
+        };
+    }
+
+    private boolean protectedPackageNameSpaces(Class<?> mockedType) {
+        return mockedType.getName().startsWith("java.");
+    }
+}

--- a/jmock-imposters/src/main/java/org/jmock/lib/imposters/package-info.java
+++ b/jmock-imposters/src/main/java/org/jmock/lib/imposters/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * These classes are tested in jmock-legacy to avoid a dependency on cglib and asm
+ * @author oliverbye
+ *
+ */
+package org.jmock.lib.imposters;

--- a/jmock-junit3/pom.xml
+++ b/jmock-junit3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0</version>
+        <version>2.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jmock-junit3</artifactId>

--- a/jmock-junit3/pom.xml
+++ b/jmock-junit3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.0</version>
     </parent>
 
     <artifactId>jmock-junit3</artifactId>

--- a/jmock-junit4/pom.xml
+++ b/jmock-junit4/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.0</version>
     </parent>
 
     <properties>

--- a/jmock-junit4/pom.xml
+++ b/jmock-junit4/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0</version>
+        <version>2.10.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jmock-junit5/pom.xml
+++ b/jmock-junit5/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>jmock-junit5</artifactId>
+
+    <parent>
+        <groupId>org.jmock</groupId>
+        <artifactId>jmock-parent</artifactId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+        </dependency>
+
+        <dependency>
+            <!-- For Autoloading JUnit5 Extensions -->
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>1.0-rc1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jmock</groupId>
+            <artifactId>jmock</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jmock</groupId>
+            <artifactId>jmock</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/jmock-junit5/src/main/java/org/jmock/junit5/JUnit5Mockery.java
+++ b/jmock-junit5/src/main/java/org/jmock/junit5/JUnit5Mockery.java
@@ -1,0 +1,76 @@
+package org.jmock.junit5;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.jmock.Mockery;
+import org.jmock.auto.internal.Mockomatic;
+import org.jmock.internal.AllDeclaredFields;
+import org.jmock.lib.AssertionErrorTranslator;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.google.auto.service.AutoService;
+
+/**
+ * A <code>JUnitRuleMockery</code> is a JUnit Rule that manages JMock
+ * expectations and allowances, and asserts that expectations have been met
+ * after each test has finished. To use it, add a field to the test class (note
+ * that you don't have to specify <code>@RunWith(JMock.class)</code> any more).
+ * For example,
+ * 
+ * <pre>
+ * public class ATestWithSatisfiedExpectations {
+ *     &#64;RegisterExtension
+ *     public final JUnitRuleMockery context = new JUnitRuleMockery();
+ *     private final Runnable runnable = context.mock(Runnable.class);
+ * 
+ *     &#64;Test
+ *     public void doesSatisfyExpectations() {
+ *         context.checking(new Expectations() {
+ *             {
+ *                 oneOf(runnable).run();
+ *             }
+ *         });
+ * 
+ *         runnable.run();
+ *     }
+ * }
+ * </pre>
+ *
+ * Note that the Rule field must be declared public and as a
+ * <code>JUnitRuleMockery</code> (not a <code>Mockery</code>) for JUnit to
+ * recognise it, as it's checked statically.
+ * 
+ * @author olibye
+ */
+@AutoService(org.junit.jupiter.api.extension.Extension.class)
+public class JUnit5Mockery extends Mockery
+        implements Extension, BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+    private final Mockomatic mockomatic = new Mockomatic(this);
+
+    public JUnit5Mockery() {
+        setExpectationErrorTranslator(AssertionErrorTranslator.INSTANCE);
+    }
+
+    private void fillInAutoMocks(final Object target, List<Field> allFields) {
+        mockomatic.fillIn(target, allFields);
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) throws Exception {
+        if (context.getTestClass().isPresent()) {
+            Class<?> testCaseClass = context.getTestClass().get();
+            List<Field> allFields = AllDeclaredFields.in(testCaseClass);
+            fillInAutoMocks(testCaseClass, allFields);
+        }
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) throws Exception {
+        assertIsSatisfied();
+    }
+}

--- a/jmock-junit5/src/main/java/org/jmock/junit5/package.html
+++ b/jmock-junit5/src/main/java/org/jmock/junit5/package.html
@@ -1,0 +1,58 @@
+<html>
+<body>
+<p>Integrates jMock with <a href="http://www.junit.org">JUnit 4</a>.</p>
+<p>To write a mock object test in JUnit 4, declare a field of type Mockery
+that holds a JUnit4Mockery and annotate your test class with 
+<code>@RunWith(JMock.class)</code>, as shown below.  The Mockery will
+be verified after the test has run and before the fixture is torn down.
+</p>
+
+<pre>
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JMock;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+...
+
+<span>@</span>RunWith(JMock.class)
+public class ExampleJUnit4MockObjectTest {
+	Mockery context = new JUnit4Mockery();
+	
+	...	
+	
+	<span>@</span>Test public void
+	dispatchesEventToSessionsOtherThanThenSender() {
+		...
+		
+		context.checking(new Expectations() {{
+			...
+		}});
+		
+		...
+	}
+}
+</pre>
+
+<p>Alternatively, from JUnit 4.7, you can use <code>JMockContext</code> which
+implements a JUnit <code>Rule</code> to manage expectations and allowances, and to
+assert the expectations after each test has run.</p>
+
+<pre>public class ATestWithSatisfiedExpectations {
+  \@Rule public final JMockContext context = new JMockContext();
+  private final Runnable runnable = context.mock(Runnable.class);
+     
+  \@Test
+  public void doesSatisfyExpectations() {
+    context.checking(new Expectations() {{
+      oneOf (runnable).run();
+    }});
+          
+    runnable.run();
+  }
+}</pre>
+
+</body>
+</html>

--- a/jmock-junit5/src/main/java/org/jmock/junit5/services/ExpectationExtension.java
+++ b/jmock-junit5/src/main/java/org/jmock/junit5/services/ExpectationExtension.java
@@ -1,0 +1,72 @@
+package org.jmock.junit5.services;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(org.junit.jupiter.api.extension.Extension.class)
+public class ExpectationExtension implements TestExecutionExceptionHandler, BeforeEachCallback, AfterEachCallback {
+
+    private Throwable thrown = null;
+    private Timer timer = null;
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        if (isAnnotated(context, ExpectationThrows.class)) {
+            if (!readExpectedFromAnnotations(context).isAssignableFrom(throwable.getClass())) {
+                throw throwable;
+            }
+            thrown = throwable;
+        }
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        if (isAnnotated(context, ExpectationThrows.class)) {
+            timer = new Timer(true);
+            timer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    Assertions.fail("Timed out");
+                }
+            }, readTimoutFromAnnotations(context));
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        if (isAnnotated(context, ExpectationThrows.class)) {
+            // TODO locking might be nice to top unexpected failures
+            timer.cancel();
+            timer = null;
+        }
+
+        if (isAnnotated(context, ExpectationThrows.class)) {
+            Class<? extends Throwable> expected = readExpectedFromAnnotations(context);
+            if (thrown == null || !expected.isAssignableFrom(thrown.getClass())) {
+                Assertions.fail("Was expecting the throwable:" + expected.getName());
+            }
+        }
+    }
+
+    private boolean isAnnotated(ExtensionContext context, Class<ExpectationThrows> annotation) {
+        return context.getRequiredTestMethod().isAnnotationPresent(annotation);
+    }
+
+    private Class<? extends Throwable> readExpectedFromAnnotations(ExtensionContext context) {
+        ExpectationThrows annotation = context.getRequiredTestMethod().getAnnotation(ExpectationThrows.class);
+        return annotation.expected();
+    }
+
+    private long readTimoutFromAnnotations(ExtensionContext context) {
+        ExpectationTimeout annotation = context.getRequiredTestMethod().getAnnotation(ExpectationTimeout.class);
+        return annotation.timeout();
+    }
+}

--- a/jmock-junit5/src/main/java/org/jmock/junit5/services/ExpectationThrows.java
+++ b/jmock-junit5/src/main/java/org/jmock/junit5/services/ExpectationThrows.java
@@ -1,0 +1,23 @@
+package org.jmock.junit5.services;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Test;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Test
+public @interface ExpectationThrows {
+
+    /**
+     * Optionally specify <code>expected</code>, a Throwable, to cause a test method
+     * to succeed if and only if an exception of the specified class is thrown by
+     * the method. If the Throwable's message or one of its properties should be
+     * verified, the {@link org.junit.rules.ExpectedException ExpectedException}
+     * rule can be used instead.
+     */
+    Class<? extends Throwable> expected();
+}

--- a/jmock-junit5/src/main/java/org/jmock/junit5/services/ExpectationTimeout.java
+++ b/jmock-junit5/src/main/java/org/jmock/junit5/services/ExpectationTimeout.java
@@ -1,0 +1,21 @@
+package org.jmock.junit5.services;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Aim to replace the old Junt4.@Test(timeout) functionality
+ * 
+ * @author oliverbye
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Test
+public @interface ExpectationTimeout {
+    /**
+     * Optionally specify <code>timeout</code> in milliseconds to cause a test
+     * method to fail if execution time exceeds <code>timeout</code> milliseconds.
+     */
+    long timeout() default 0L;
+}

--- a/jmock-junit5/src/main/java/org/jmock/junit5/services/package-info.java
+++ b/jmock-junit5/src/main/java/org/jmock/junit5/services/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * 
+ */
+/**
+ * @author oliverbye
+ *
+ */
+package org.jmock.junit5.services;

--- a/jmock-junit5/src/test/java/org/jmock/junit5/acceptance/FailureRecordingTestExecutionListener.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/acceptance/FailureRecordingTestExecutionListener.java
@@ -1,0 +1,54 @@
+package org.jmock.junit5.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(TestExecutionListener.class)
+public class FailureRecordingTestExecutionListener implements TestExecutionListener {
+
+    TestExecutionResult testExecutionResult;
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        this.testExecutionResult = testExecutionResult;
+    }
+
+    public void assertTestSucceeded() {
+        if (testExecutionResult.getStatus().equals(Status.FAILED)) {
+            fail("test should have passed but reported failure: " + testExecutionResult.toString());
+        }
+    }
+
+    public void assertTestFailedWith(Class<? extends Throwable> exceptionType) {
+        assertEquals(Status.FAILED, testExecutionResult.getStatus(), "test should have failed");
+        Throwable cause = testExecutionResult.getThrowable().get();
+        assertTrue(exceptionType.isInstance(cause),
+                "should have failed with " + exceptionType.getName() + " but threw " + cause);
+    }
+
+    public void assertTestFailedWithInitializationError() {
+        assertEquals(Status.FAILED, testExecutionResult.getStatus(), "test should have failed");
+        assertTrue(testExecutionResult.toString().contains("initializationError"),
+                "should have failed with initialization error, but failure was " + testExecutionResult.toString());
+    }
+
+    public void runTestIn(Class<?> testClass) {
+        Launcher launcher = LauncherFactory.create();
+        launcher.registerTestExecutionListeners(this);
+        launcher.execute(LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(testClass))
+                .build());
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/acceptance/JUnit5TestRunnerTests.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/acceptance/JUnit5TestRunnerTests.java
@@ -1,0 +1,80 @@
+package org.jmock.junit5.acceptance;
+
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.junit5.testdata.DerivedJUnit4TestThatDoesNotSatisfyExpectations;
+import org.jmock.junit5.testdata.JUnit5TestThatAutoInstantiatesMocks;
+import org.jmock.junit5.testdata.JUnit5TestThatCreatesNoMockery;
+import org.jmock.junit5.testdata.JUnit5TestThatCreatesTwoMockeries;
+import org.jmock.junit5.testdata.JUnit5TestThatDoesNotCreateAMockery;
+import org.jmock.junit5.testdata.JUnit5TestThatDoesNotSatisfyExpectations;
+import org.jmock.junit5.testdata.JUnit5TestThatDoesSatisfyExpectations;
+import org.jmock.junit5.testdata.JUnit5TestThatThrowsExpectedException;
+import org.jmock.junit5.testdata.JUnit5TestWithNonPublicBeforeMethod;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(JUnit5Mockery.class)
+public class JUnit5TestRunnerTests {
+    FailureRecordingTestExecutionListener listener = new FailureRecordingTestExecutionListener();
+    
+    @Test
+    public void testTheJUnit4TestRunnerReportsPassingTestsAsSuccessful() {
+        listener.runTestIn(JUnit5TestThatDoesSatisfyExpectations.class);
+        listener.assertTestSucceeded();
+    }
+    
+    @Test
+    public void testTheJUnit4TestRunnerAutomaticallyAssertsThatAllExpectationsHaveBeenSatisfied() {
+        listener.runTestIn(JUnit5TestThatDoesNotSatisfyExpectations.class);
+        listener.assertTestFailedWith(AssertionError.class);
+    }
+    
+    @Test
+    public void testTheJUnit4TestRunnerLooksForTheMockeryInBaseClasses() {
+        listener.runTestIn(DerivedJUnit4TestThatDoesNotSatisfyExpectations.class);
+        listener.assertTestFailedWith(AssertionError.class);
+    }
+    
+    @Test
+    public void testTheJUnit4TestRunnerReportsAHelpfulErrorIfTheMockeryIsNull() {
+        listener.runTestIn(JUnit5TestThatDoesNotCreateAMockery.class);
+        listener.assertTestFailedWith(IllegalStateException.class);
+    }
+    
+    // See issue JMOCK-156
+    @Test
+    public void testReportsMocksAreNotSatisfiedWhenExpectedExceptionIsThrown() {
+        listener.runTestIn(JUnit5TestThatThrowsExpectedException.class);
+        listener.assertTestFailedWith(AssertionError.class);
+    }
+
+    // See issue JMOCK-219
+    @Test
+    public void testTheJUnit4TestRunnerReportsIfNoMockeryIsFound() {
+        listener.runTestIn(JUnit5TestThatCreatesNoMockery.class);
+        listener.assertTestFailedWithInitializationError();
+    }
+
+    // See issue JMOCK-219
+    @Test
+    public void testTheJUnit4TestRunnerReportsIfMoreThanOneMockeryIsFound() {
+        listener.runTestIn(JUnit5TestThatCreatesTwoMockeries.class);
+        listener.assertTestFailedWithInitializationError();
+    }
+    
+    @Test
+    public void testDetectsNonPublicBeforeMethodsCorrectly() {
+        listener.runTestIn(JUnit5TestWithNonPublicBeforeMethod.class);
+        listener.assertTestFailedWith(Throwable.class);
+        Assertions.assertEquals("should have detected non-public before method",
+                "Method before() should be public",
+                       listener.testExecutionResult.toString());
+    }
+    
+    @Test
+    public void testAutoInstantiatesMocks() {
+        listener.runTestIn(JUnit5TestThatAutoInstantiatesMocks.class);
+        listener.assertTestSucceeded();
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/acceptance/JUnit5WithRulesTestRunnerTests.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/acceptance/JUnit5WithRulesTestRunnerTests.java
@@ -1,0 +1,46 @@
+package org.jmock.junit5.acceptance;
+
+import org.jmock.junit5.testdata.JUnit5WithRulesExamples;
+import org.junit.jupiter.api.Test;
+
+public class JUnit5WithRulesTestRunnerTests {
+    FailureRecordingTestExecutionListener listener = new FailureRecordingTestExecutionListener();
+    
+    @Test
+    public void testTheJUnit4TestRunnerReportsPassingTestsAsSuccessful() {
+        listener.runTestIn(JUnit5WithRulesExamples.SatisfiesExpectations.class);
+        listener.assertTestSucceeded();
+    }
+    
+    @Test
+    public void testTheJUnit4TestRunnerAutomaticallyAssertsThatAllExpectationsHaveBeenSatisfied() {
+        listener.runTestIn(JUnit5WithRulesExamples.DoesNotSatisfyExpectations.class);
+        listener.assertTestFailedWith(AssertionError.class);
+    }
+    
+    @Test
+    public void testTheJUnit4TestRunnerLooksForTheMockeryInBaseClasses() {
+        listener.runTestIn(JUnit5WithRulesExamples.DerivedAndDoesNotSatisfyExpectations.class);
+        listener.assertTestFailedWith(AssertionError.class);
+    }
+
+    
+    // See issue JMOCK-156
+    @Test
+    public void testReportsMocksAreNotSatisfiedWhenExpectedExceptionIsThrown() {
+        listener.runTestIn(JUnit5WithRulesExamples.ThrowsExpectedException.class);
+        listener.assertTestFailedWith(AssertionError.class);
+    }
+    
+    @Test
+    public void testFailsWhenMoreThanOneJMockContextField() {
+        listener.runTestIn(JUnit5WithRulesExamples.CreatesTwoMockeries.class);
+        listener.assertTestFailedWith(AssertionError.class);
+    }
+
+    @Test
+    public void testAutoInstantiatesMocks() {
+        listener.runTestIn(JUnit5WithRulesExamples.AutoInstantiatesMocks.class);
+        listener.assertTestSucceeded();
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/BaseClassWithMockery.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/BaseClassWithMockery.java
@@ -1,0 +1,9 @@
+package org.jmock.junit5.testdata;
+
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(JUnit5Mockery.class)
+public class BaseClassWithMockery {
+    protected JUnit5Mockery context = new JUnit5Mockery();
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/DerivedJUnit4TestThatDoesNotSatisfyExpectations.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/DerivedJUnit4TestThatDoesNotSatisfyExpectations.java
@@ -1,0 +1,17 @@
+package org.jmock.junit5.testdata;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+public class DerivedJUnit4TestThatDoesNotSatisfyExpectations extends BaseClassWithMockery {
+    private Runnable runnable = context.mock(Runnable.class);
+    
+    @Test
+    public void doesNotSatisfyExpectations() {
+        context.checking(new Expectations() {{
+            oneOf (runnable).run();
+        }});
+        
+        // Return without satisfying the expectation for runnable.run()
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatAutoInstantiatesMocks.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatAutoInstantiatesMocks.java
@@ -1,0 +1,22 @@
+package org.jmock.junit5.testdata;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.jmock.Sequence;
+import org.jmock.States;
+import org.jmock.auto.Auto;
+import org.jmock.auto.Mock;
+
+public class JUnit5TestThatAutoInstantiatesMocks extends BaseClassWithMockery {
+    @Mock Runnable runnable;
+    @Auto States states;
+    @Auto Sequence sequence;
+    
+    @org.junit.jupiter.api.Test
+    public void fieldsHaveBeenAutoInstantiated() {
+        assertThat(runnable, notNullValue());
+        assertThat(states, notNullValue());
+        assertThat(sequence, notNullValue());
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatCreatesNoMockery.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatCreatesNoMockery.java
@@ -1,0 +1,13 @@
+package org.jmock.junit5.testdata;
+
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(JUnit5Mockery.class)
+public class JUnit5TestThatCreatesNoMockery {
+    @Test
+    public void happy() {
+        // a-ok!
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatCreatesTwoMockeries.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatCreatesTwoMockeries.java
@@ -1,0 +1,18 @@
+package org.jmock.junit5.testdata;
+
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JUnit5TestThatCreatesTwoMockeries {
+    @RegisterExtension
+    JUnit5Mockery contextA = new JUnit5Mockery();
+    @RegisterExtension
+    JUnit5Mockery contextB = new JUnit5Mockery();
+    
+    @Test
+    public void happy() {
+        // a-ok!
+    }
+
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatDoesNotCreateAMockery.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatDoesNotCreateAMockery.java
@@ -1,0 +1,15 @@
+package org.jmock.junit5.testdata;
+
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JUnit5TestThatDoesNotCreateAMockery {
+    @RegisterExtension
+    JUnit5Mockery context = null;
+    
+    @Test
+    public void happy() {
+        // a-ok!
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatDoesNotSatisfyExpectations.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatDoesNotSatisfyExpectations.java
@@ -1,0 +1,20 @@
+package org.jmock.junit5.testdata;
+
+import org.jmock.Expectations;
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JUnit5TestThatDoesNotSatisfyExpectations {
+    @RegisterExtension
+    private JUnit5Mockery context = new JUnit5Mockery();
+    private Runnable runnable = context.mock(Runnable.class);
+    
+    @org.junit.jupiter.api.Test
+    public void doesNotSatisfyExpectations() {
+        context.checking(new Expectations() {{
+            oneOf (runnable).run();
+        }});
+        
+        // Return without satisfying the expectation for runnable.run()
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatDoesSatisfyExpectations.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatDoesSatisfyExpectations.java
@@ -1,0 +1,21 @@
+package org.jmock.junit5.testdata;
+
+import org.jmock.Expectations;
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JUnit5TestThatDoesSatisfyExpectations {
+    @RegisterExtension
+    private JUnit5Mockery context = new JUnit5Mockery();
+    private Runnable runnable = context.mock(Runnable.class);
+    
+    @Test
+    public void doesSatisfyExpectations() {
+        context.checking(new Expectations() {{
+            oneOf (runnable).run();
+        }});
+        
+        runnable.run();
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatThrowsExpectedException.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestThatThrowsExpectedException.java
@@ -1,0 +1,36 @@
+package org.jmock.junit5.testdata;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.junit5.services.ExpectationThrows;
+import org.jmock.junit5.services.ExpectationExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@ExtendWith(ExpectationExtension.class)
+public class JUnit5TestThatThrowsExpectedException {
+    @RegisterExtension
+    private Mockery context = new JUnit5Mockery();
+    private WithException withException = context.mock(WithException.class);
+    
+    @Test
+    @ExpectationThrows(expected=CheckedException.class)
+    public void doesNotSatisfyExpectationsWhenExpectedExceptionIsThrown() throws CheckedException {
+        context.checking(new Expectations() {{
+            oneOf (withException).anotherMethod();
+            oneOf (withException).throwingMethod(); will(throwException(new CheckedException()));
+        }});
+        
+        withException.throwingMethod();
+    }
+    
+    public static class  CheckedException extends Exception {
+    }
+    
+    public interface WithException {
+        void throwingMethod() throws CheckedException;
+        void anotherMethod();
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestWithNonPublicBeforeMethod.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5TestWithNonPublicBeforeMethod.java
@@ -1,0 +1,26 @@
+package org.jmock.junit5.testdata;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(JUnit5Mockery.class)
+public class JUnit5TestWithNonPublicBeforeMethod {
+    @SuppressWarnings("unused")
+    private Mockery context = new Mockery();
+
+    public boolean beforeWasCalled = false;
+
+    @BeforeEach
+    void before() {
+        beforeWasCalled = true;
+    }
+
+    @org.junit.jupiter.api.Test
+    public void beforeShouldBeCalled() {
+        assertTrue(beforeWasCalled, "before was called");
+    }
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5WithRulesExamples.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/testdata/JUnit5WithRulesExamples.java
@@ -1,0 +1,114 @@
+package org.jmock.junit5.testdata;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.jmock.Expectations;
+import org.jmock.Sequence;
+import org.jmock.States;
+import org.jmock.auto.Auto;
+import org.jmock.auto.Mock;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.junit5.services.ExpectationThrows;
+import org.jmock.junit5.services.ExpectationExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JUnit5WithRulesExamples {
+    public static class SatisfiesExpectations {
+        @RegisterExtension public final JUnit5Mockery context = new JUnit5Mockery();
+        private final Runnable runnable = context.mock(Runnable.class);
+        
+        @Test
+        public void doesSatisfyExpectations() {
+            context.checking(new Expectations() {{
+                oneOf (runnable).run();
+            }});
+            
+            runnable.run();
+        }
+    }
+    
+    public static class DoesNotSatisfyExpectations {
+        @RegisterExtension public final JUnit5Mockery context = new JUnit5Mockery();
+        private Runnable runnable = context.mock(Runnable.class);
+        
+        @Test
+        public void doesNotSatisfyExpectations() {
+            context.checking(new Expectations() {{
+                oneOf (runnable).run();
+            }});
+            
+            // Return without satisfying the expectation for runnable.run()
+        }
+    }
+
+    
+    public static class DerivedAndDoesNotSatisfyExpectations extends BaseClassWithJMockContext {
+        private Runnable runnable = context.mock(Runnable.class);
+        
+        @Test
+        public void doesNotSatisfyExpectations() {
+            context.checking(new Expectations() {{
+                oneOf (runnable).run();
+            }});
+            
+            // Return without satisfying the expectation for runnable.run()
+        }
+    }
+
+    @ExtendWith(ExpectationExtension.class)
+    public static class ThrowsExpectedException {
+        @RegisterExtension public final JUnit5Mockery context = new JUnit5Mockery();
+        private WithException withException = context.mock(WithException.class);
+        
+        @Test
+        @ExpectationThrows(expected=CheckedException.class)
+        public void doesNotSatisfyExpectationsWhenExpectedExceptionIsThrown() throws CheckedException {
+            context.checking(new Expectations() {{
+                oneOf (withException).anotherMethod();
+                oneOf (withException).throwingMethod(); will(throwException(new CheckedException()));
+            }});
+            
+            withException.throwingMethod();
+        }
+        
+        @SuppressWarnings("serial")
+        public static class  CheckedException extends Exception {
+        }
+        
+        public interface WithException {
+            void throwingMethod() throws CheckedException;
+            void anotherMethod();
+        }
+    }
+
+    public static class CreatesTwoMockeries extends BaseClassWithJMockContext {
+        @RegisterExtension public final JUnit5Mockery context = new JUnit5Mockery();
+
+        @Test
+        public void doesNothing() {
+            // no op
+        }
+    }
+
+    public static class AutoInstantiatesMocks extends BaseClassWithJMockContext {
+        @Mock Runnable runnable;
+        @Auto States states;
+        @Auto Sequence sequence;
+        
+        @Test
+        public void fieldsHaveBeenAutoInstantiated() {
+            assertThat("runnable", runnable, notNullValue());
+            assertThat("states", states, notNullValue());
+            assertThat("sequence", sequence, notNullValue());
+        }
+    }
+
+    
+    public static class BaseClassWithJMockContext {
+        @RegisterExtension public final JUnit5Mockery context = new JUnit5Mockery();
+    }
+
+}

--- a/jmock-junit5/src/test/java/org/jmock/junit5/unit/lib/concurrent/internal/SynchroniserTests.java
+++ b/jmock-junit5/src/test/java/org/jmock/junit5/unit/lib/concurrent/internal/SynchroniserTests.java
@@ -1,0 +1,177 @@
+package org.jmock.junit5.unit.lib.concurrent.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jmock.Expectations;
+import org.jmock.States;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.junit5.services.ExpectationTimeout;
+import org.jmock.lib.concurrent.Blitzer;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SynchroniserTests {
+    public interface Events {
+        void action();
+        void finished();
+    }
+    
+    Synchroniser synchroniser = new Synchroniser();
+    @RegisterExtension
+    JUnit5Mockery mockery = new JUnit5Mockery() {{
+        setThreadingPolicy(synchroniser);
+    }};
+    
+    Blitzer blitzer = new Blitzer(16, 4);
+    
+    Events mockObject = mockery.mock(Events.class, "mockObject");
+    
+    @Test
+    @ExpectationTimeout(timeout=250)
+    public void allowsMultipleThreadsToCallMockObjects() throws InterruptedException {
+        mockery.checking(new Expectations() {{
+            exactly(blitzer.totalActionCount()).of(mockObject).action();
+        }});
+        
+        blitzer.blitz(new Runnable() {
+            public void run() {
+                mockObject.action();
+            }
+        });
+        
+        mockery.assertIsSatisfied();
+    }
+    
+    @Test
+    @ExpectationTimeout(timeout=250)
+    public void canWaitForAStateMachineToEnterAGivenState() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger(blitzer.totalActionCount());
+        
+        final States threads = mockery.states("threads");
+        
+        mockery.checking(new Expectations() {{
+            exactly(blitzer.totalActionCount()).of(mockObject).action();
+                when(threads.isNot("finished"));
+                
+            oneOf(mockObject).finished();
+                then(threads.is("finished"));
+        }});
+        
+        blitzer.blitz(new Runnable() {
+            public void run() {
+                mockObject.action();
+                if (counter.decrementAndGet() == 0) {
+                    mockObject.finished();
+                }
+            }
+        });
+        
+        synchroniser.waitUntil(threads.is("finished"));
+    }
+
+    @Test
+    @ExpectationTimeout(timeout=250)
+    public void canWaitForAStateMachineToEnterAGivenStateWithinSomeTimeout() throws InterruptedException {
+        final States threads = mockery.states("threads");
+        
+        mockery.checking(new Expectations() {{
+            exactly(blitzer.totalActionCount()).of(mockObject).action();
+                when(threads.isNot("finished"));
+                
+            oneOf(mockObject).finished();
+                then(threads.is("finished"));
+        }});
+        
+        blitzer.blitz(new Runnable() {
+            AtomicInteger counter = new AtomicInteger(blitzer.totalActionCount());
+            
+            public void run() {
+                mockObject.action();
+                if (counter.decrementAndGet() == 0) {
+                    mockObject.finished();
+                }
+            }
+        });
+        
+        synchroniser.waitUntil(threads.is("finished"), 100);
+    }
+
+    @Test
+    @ExpectationTimeout(timeout=250)
+    public void failsTheTestIfStateMachineDoesNotEnterExpectedStateWithinTimeout() throws InterruptedException {
+        States threads = mockery.states("threads");
+        
+        try {
+            synchroniser.waitUntil(threads.is("finished"), 100);
+        }
+        catch (AssertionError e) {
+            return;
+        }
+        
+        fail("should have thrown AssertionError");
+    }
+    
+    @Test
+    public void throwsExpectationErrorIfExpectationFailsWhileWaitingForStateMachine() throws InterruptedException {
+        final States threads = mockery.states("threads");
+        
+        // This will cause an expectation error, and nothing will make
+        // the "threads" state machine transition to "finished" 
+        
+        blitzer.blitz(new Runnable() {
+            public void run() {
+                mockObject.action();
+            }
+        });
+        
+        try {
+            synchroniser.waitUntil(threads.is("finished"), 100);
+            fail("should have thrown AssertionError");
+        }
+        catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("action()"));
+        }
+    }
+
+    @Test
+    public void throwsExpectationErrorIfExpectationFailsWhileWaitingForStateMachineEvenIfWaitSucceeds() throws InterruptedException {
+        final States threads = mockery.states("threads");
+        
+        mockery.checking(new Expectations() {{
+            oneOf(mockObject).finished();
+                then(threads.is("finished"));
+        }});
+        
+        blitzer.blitz(new Runnable() {
+            AtomicInteger counter = new AtomicInteger(blitzer.totalActionCount());
+            
+            public void run() {
+                if (counter.decrementAndGet() == 0) {
+                    mockObject.finished();
+                }
+                else {
+                    mockObject.action();
+                }
+            }
+        });
+        
+        try {
+            synchroniser.waitUntil(threads.is("finished"), 100);
+            fail("should have thrown AssertionError");
+        }
+        catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("action()"));
+        }
+    }
+    
+    @AfterEach
+    public void cleanUp() {
+        blitzer.shutdown();
+    }
+}

--- a/jmock-legacy/pom.xml
+++ b/jmock-legacy/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.0</version>
     </parent>
 
     <properties>

--- a/jmock-legacy/pom.xml
+++ b/jmock-legacy/pom.xml
@@ -46,6 +46,10 @@
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
         </dependency>
+<dependency>
+    <groupId>net.bytebuddy</groupId>
+    <artifactId>byte-buddy</artifactId>
+</dependency>
     </dependencies>
 
 </project>

--- a/jmock-legacy/pom.xml
+++ b/jmock-legacy/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>jmock-legacy</artifactId>
@@ -8,20 +10,27 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0</version>
+        <version>2.10.0-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cglib.version>3.2.8</cglib.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
         </dependency>
-        
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock</artifactId>
@@ -41,15 +50,27 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jmock</groupId>
+            <artifactId>jmock-imposters</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
         </dependency>
-<dependency>
-    <groupId>net.bytebuddy</groupId>
-    <artifactId>byte-buddy</artifactId>
-</dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>${cglib.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jmock-legacy/src/main/java/org/jmock/lib/legacy/ClassImposteriser.java
+++ b/jmock-legacy/src/main/java/org/jmock/lib/legacy/ClassImposteriser.java
@@ -1,11 +1,10 @@
 package org.jmock.lib.legacy;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-
+import net.sf.cglib.core.CodeGenerationException;
+import net.sf.cglib.core.DefaultNamingPolicy;
+import net.sf.cglib.core.NamingPolicy;
+import net.sf.cglib.core.Predicate;
+import net.sf.cglib.proxy.*;
 import org.jmock.api.Imposteriser;
 import org.jmock.api.Invocation;
 import org.jmock.api.Invokable;
@@ -13,70 +12,76 @@ import org.jmock.internal.SearchingClassLoader;
 import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisStd;
 
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.NamingStrategy;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType.Builder;
-import net.bytebuddy.dynamic.loading.ClassInjector;
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
-import net.bytebuddy.implementation.InvocationHandlerAdapter;
-import net.bytebuddy.matcher.ElementMatchers;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.List;
 
 /**
- * This class lets you imposterise abstract and concrete classes
+ * This class lets you imposterise abstract and concrete classes 
  * <em>without</em> calling the constructors of the mocked class.
- * 
+ *   
  * @author npryce
+ * 
+ * @deprecated Migrate to @see org.jmock.lib.legacy.ByteBuddyClassImposteriser
  */
 public class ClassImposteriser implements Imposteriser {
     public static final Imposteriser INSTANCE = new ClassImposteriser();
-
-    private ClassImposteriser() {
-    }
+    
+    private ClassImposteriser() {}
 
     private static final Method FINALIZE_METHOD = findFinalizeMethod();
 
-    private static final NamingStrategy.AbstractBase NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES = new NamingStrategy.AbstractBase() {
+    private static final NamingPolicy NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES = new DefaultNamingPolicy() {
         @Override
-        protected String name(TypeDescription superClass) {
-            return "org.jmock.codegen." + superClass.getActualName();
+        public String getClassName(String prefix, String source, Object key, Predicate names) {
+            return "org.jmock.codegen." + super.getClassName(prefix, source, key, names);
         }
     };
-
-    /*
-     * private static final CallbackFilter IGNORED_METHODS = new CallbackFilter() {
-     * public int accept(Method method) { if (method.isBridge()) return 1; else if
-     * (method.equals(FINALIZE_METHOD)) return 1; else return 0; } };
-     */
+    
+    private static final CallbackFilter IGNORED_METHODS = new CallbackFilter() {
+        public int accept(Method method) {
+            if (method.isBridge())
+                return 1;
+            else if (method.equals(FINALIZE_METHOD))
+                return 1;
+            else
+                return 0;
+        }
+    };
+    
     private final Objenesis objenesis = new ObjenesisStd();
-
+    
     public boolean canImposterise(Class<?> type) {
-        return !type.isPrimitive() &&
-                !Modifier.isFinal(type.getModifiers()) &&
-                (type.isInterface() || !toStringMethodIsFinal(type));
+        return !type.isPrimitive() && 
+               !Modifier.isFinal(type.getModifiers()) && 
+               (type.isInterface() || !toStringMethodIsFinal(type));
     }
-
+    
     public <T> T imposterise(final Invokable mockObject, Class<T> mockedType, Class<?>... ancilliaryTypes) {
         if (!mockedType.isInterface() && toStringMethodIsFinal(mockedType)) {
             throw new IllegalArgumentException(mockedType.getName() + " has a final toString method");
         }
-
+        
         try {
             setConstructorsAccessible(mockedType, true);
-            return mockedType.cast(proxy(mockObject, mockedType, ancilliaryTypes));
-        } finally {
+          return mockedType.cast(proxy(proxyClass(mockedType, ancilliaryTypes), mockObject));
+        }
+        finally {
             setConstructorsAccessible(mockedType, false);
         }
     }
-
+    
     private boolean toStringMethodIsFinal(Class<?> type) {
         try {
             Method toString = type.getMethod("toString");
             return Modifier.isFinal(toString.getModifiers());
-
-        } catch (SecurityException e) {
+            
+        }
+        catch (SecurityException e) {
             throw new IllegalStateException("not allowed to reflect on toString method", e);
-        } catch (NoSuchMethodException e) {
+        }
+        catch (NoSuchMethodException e) {
             throw new Error("no public toString method found", e);
         }
     }
@@ -86,49 +91,63 @@ public class ClassImposteriser implements Imposteriser {
             constructor.setAccessible(accessible);
         }
     }
-
-    private Object proxy(final Invokable mockObject, Class<?> mockedType, Class<?>... ancilliaryTypes) {
-
-        Builder<?> builder = new ByteBuddy().subclass(mockedType)
-                .implement(ancilliaryTypes)
-                .method(ElementMatchers.any())
-                .intercept(InvocationHandlerAdapter.of(new InvocationHandler() {
-                    public Object invoke(Object receiver, Method method, Object[] args) throws Throwable {
-                        return mockObject.invoke(new Invocation(receiver, method, args));
-                    }
-                }));
-
-        // enhancer.setCallbackFilter(IGNORED_METHODS);
-        // if (mockedType.getSigners() != null) {
-        // enhancer.setNamingPolicy(NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES);
-        // }
-
-        // From
-        // https://mydailyjava.blogspot.com/2018/04/jdk-11-and-proxies-in-world-past.html
-        try {
-            ClassLoadingStrategy<ClassLoader> strategy;
-            if (ClassInjector.UsingLookup.isAvailable()) {
-                Class<?> methodHandles = Class.forName("java.lang.invoke.MethodHandles");
-                Object lookup = methodHandles.getMethod("lookup").invoke(null);
-                Method privateLookupIn = methodHandles.getMethod("privateLookupIn",
-                        Class.class,
-                        Class.forName("java.lang.invoke.MethodHandles$Lookup"));
-                Object privateLookup = privateLookupIn.invoke(null, mockedType, lookup);
-                strategy = ClassLoadingStrategy.UsingLookup.of(privateLookup);
-            } else if (ClassInjector.UsingReflection.isAvailable()) {
-                strategy = ClassLoadingStrategy.Default.INJECTION;
-            } else {
-                throw new IllegalStateException("No code generation strategy available");
+    
+    private Class<?> proxyClass(Class<?> possibleMockedType, Class<?>... ancilliaryTypes) {
+        final Class<?> mockedType =
+            possibleMockedType == Object.class ? ClassWithSuperclassToWorkAroundCglibBug.class : possibleMockedType;
+        
+        final Enhancer enhancer = new Enhancer() {
+            @Override
+            @SuppressWarnings("unchecked")
+            protected void filterConstructors(Class sc, List constructors) {
+                // Don't filter
             }
-
-            return objenesis.newInstance(builder.make()
-                    .load(SearchingClassLoader.combineLoadersOf(mockedType, ancilliaryTypes), strategy)
-                    .getLoaded());
-            
-        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
-                | SecurityException | ClassNotFoundException e) {
-            throw new RuntimeException("Exception in code generation strategy available", e);
+        };
+        enhancer.setClassLoader(SearchingClassLoader.combineLoadersOf(mockedType, ancilliaryTypes));
+        enhancer.setUseFactory(true);
+        if (mockedType.isInterface()) {
+            enhancer.setSuperclass(Object.class);
+            enhancer.setInterfaces(prepend(mockedType, ancilliaryTypes));
         }
+        else {
+            enhancer.setSuperclass(mockedType);
+            enhancer.setInterfaces(ancilliaryTypes);
+        }
+        enhancer.setCallbackTypes(new Class[]{InvocationHandler.class, NoOp.class});
+        enhancer.setCallbackFilter(IGNORED_METHODS);
+        if (protectedPackageNamespace(mockedType)) {
+            enhancer.setNamingPolicy(NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES);
+        }
+        
+        try {
+            return enhancer.createClass();
+        }
+        catch (CodeGenerationException e) {
+            // Note: I've only been able to manually test this.  It exists to help people writing
+            //       Eclipse plug-ins or using other environments that have sophisticated class loader
+            //       structures.
+            throw new IllegalArgumentException("could not imposterise " + mockedType, e);
+        }
+    }
+    
+    private Object proxy(Class<?> proxyClass, final Invokable mockObject) {
+        final Factory proxy = (Factory)objenesis.newInstance(proxyClass);
+        proxy.setCallbacks(new Callback[] {
+            new InvocationHandler() {
+                public Object invoke(Object receiver, Method method, Object[] args) throws Throwable {
+                    return mockObject.invoke(new Invocation(receiver, method, args));
+                }
+            },
+            NoOp.INSTANCE
+        });
+        return proxy;
+    }
+    
+    private Class<?>[] prepend(Class<?> first, Class<?>... rest) {
+        Class<?>[] all = new Class<?>[rest.length+1];
+        all[0] = first;
+        System.arraycopy(rest, 0, all, 1, rest.length);
+        return all;
     }
 
     private static Method findFinalizeMethod() {
@@ -138,7 +157,11 @@ public class ClassImposteriser implements Imposteriser {
             throw new IllegalStateException("Could not find finalize method on Object");
         }
     }
-
-    public static class ClassWithSuperclassToWorkAroundCglibBug {
+    
+    private boolean protectedPackageNamespace(Class<?> mockedType) {
+        return mockedType.getSigners() != null || mockedType.getName().startsWith("java.");
     }
+
+    
+    public static class ClassWithSuperclassToWorkAroundCglibBug {}
 }

--- a/jmock-legacy/src/main/java/org/jmock/lib/legacy/ClassImposteriser.java
+++ b/jmock-legacy/src/main/java/org/jmock/lib/legacy/ClassImposteriser.java
@@ -1,10 +1,11 @@
 package org.jmock.lib.legacy;
 
-import net.sf.cglib.core.CodeGenerationException;
-import net.sf.cglib.core.DefaultNamingPolicy;
-import net.sf.cglib.core.NamingPolicy;
-import net.sf.cglib.core.Predicate;
-import net.sf.cglib.proxy.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
 import org.jmock.api.Imposteriser;
 import org.jmock.api.Invocation;
 import org.jmock.api.Invokable;
@@ -12,74 +13,70 @@ import org.jmock.internal.SearchingClassLoader;
 import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisStd;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.List;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.NamingStrategy;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+import net.bytebuddy.dynamic.loading.ClassInjector;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.InvocationHandlerAdapter;
+import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * This class lets you imposterise abstract and concrete classes 
+ * This class lets you imposterise abstract and concrete classes
  * <em>without</em> calling the constructors of the mocked class.
- *   
+ * 
  * @author npryce
  */
 public class ClassImposteriser implements Imposteriser {
     public static final Imposteriser INSTANCE = new ClassImposteriser();
-    
-    private ClassImposteriser() {}
+
+    private ClassImposteriser() {
+    }
 
     private static final Method FINALIZE_METHOD = findFinalizeMethod();
 
-    private static final NamingPolicy NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES = new DefaultNamingPolicy() {
+    private static final NamingStrategy.AbstractBase NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES = new NamingStrategy.AbstractBase() {
         @Override
-        public String getClassName(String prefix, String source, Object key, Predicate names) {
-            return "org.jmock.codegen." + super.getClassName(prefix, source, key, names);
+        protected String name(TypeDescription superClass) {
+            return "org.jmock.codegen." + superClass.getActualName();
         }
     };
-    
-    private static final CallbackFilter IGNORED_METHODS = new CallbackFilter() {
-        public int accept(Method method) {
-            if (method.isBridge())
-                return 1;
-            else if (method.equals(FINALIZE_METHOD))
-                return 1;
-            else
-                return 0;
-        }
-    };
-    
+
+    /*
+     * private static final CallbackFilter IGNORED_METHODS = new CallbackFilter() {
+     * public int accept(Method method) { if (method.isBridge()) return 1; else if
+     * (method.equals(FINALIZE_METHOD)) return 1; else return 0; } };
+     */
     private final Objenesis objenesis = new ObjenesisStd();
-    
+
     public boolean canImposterise(Class<?> type) {
-        return !type.isPrimitive() && 
-               !Modifier.isFinal(type.getModifiers()) && 
-               (type.isInterface() || !toStringMethodIsFinal(type));
+        return !type.isPrimitive() &&
+                !Modifier.isFinal(type.getModifiers()) &&
+                (type.isInterface() || !toStringMethodIsFinal(type));
     }
-    
+
     public <T> T imposterise(final Invokable mockObject, Class<T> mockedType, Class<?>... ancilliaryTypes) {
         if (!mockedType.isInterface() && toStringMethodIsFinal(mockedType)) {
             throw new IllegalArgumentException(mockedType.getName() + " has a final toString method");
         }
-        
+
         try {
             setConstructorsAccessible(mockedType, true);
-          return mockedType.cast(proxy(proxyClass(mockedType, ancilliaryTypes), mockObject));
-        }
-        finally {
+            return mockedType.cast(proxy(mockObject, mockedType, ancilliaryTypes));
+        } finally {
             setConstructorsAccessible(mockedType, false);
         }
-	}
-    
+    }
+
     private boolean toStringMethodIsFinal(Class<?> type) {
         try {
             Method toString = type.getMethod("toString");
             return Modifier.isFinal(toString.getModifiers());
-            
-        }
-        catch (SecurityException e) {
+
+        } catch (SecurityException e) {
             throw new IllegalStateException("not allowed to reflect on toString method", e);
-        }
-        catch (NoSuchMethodException e) {
+        } catch (NoSuchMethodException e) {
             throw new Error("no public toString method found", e);
         }
     }
@@ -89,63 +86,49 @@ public class ClassImposteriser implements Imposteriser {
             constructor.setAccessible(accessible);
         }
     }
-    
-    private Class<?> proxyClass(Class<?> possibleMockedType, Class<?>... ancilliaryTypes) {
-        final Class<?> mockedType =
-            possibleMockedType == Object.class ? ClassWithSuperclassToWorkAroundCglibBug.class : possibleMockedType;
-        
-        final Enhancer enhancer = new Enhancer() {
-            @Override
-            @SuppressWarnings("unchecked")
-            protected void filterConstructors(Class sc, List constructors) {
-                // Don't filter
-            }
-        };
-        enhancer.setClassLoader(SearchingClassLoader.combineLoadersOf(mockedType, ancilliaryTypes));
-        enhancer.setUseFactory(true);
-        if (mockedType.isInterface()) {
-            enhancer.setSuperclass(Object.class);
-            enhancer.setInterfaces(prepend(mockedType, ancilliaryTypes));
-        }
-        else {
-            enhancer.setSuperclass(mockedType);
-            enhancer.setInterfaces(ancilliaryTypes);
-        }
-        enhancer.setCallbackTypes(new Class[]{InvocationHandler.class, NoOp.class});
-        enhancer.setCallbackFilter(IGNORED_METHODS);
-        if (mockedType.getSigners() != null) {
-            enhancer.setNamingPolicy(NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES);
-        }
-        
+
+    private Object proxy(final Invokable mockObject, Class<?> mockedType, Class<?>... ancilliaryTypes) {
+
+        Builder<?> builder = new ByteBuddy().subclass(mockedType)
+                .implement(ancilliaryTypes)
+                .method(ElementMatchers.any())
+                .intercept(InvocationHandlerAdapter.of(new InvocationHandler() {
+                    public Object invoke(Object receiver, Method method, Object[] args) throws Throwable {
+                        return mockObject.invoke(new Invocation(receiver, method, args));
+                    }
+                }));
+
+        // enhancer.setCallbackFilter(IGNORED_METHODS);
+        // if (mockedType.getSigners() != null) {
+        // enhancer.setNamingPolicy(NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES);
+        // }
+
+        // From
+        // https://mydailyjava.blogspot.com/2018/04/jdk-11-and-proxies-in-world-past.html
         try {
-            return enhancer.createClass();
+            ClassLoadingStrategy<ClassLoader> strategy;
+            if (ClassInjector.UsingLookup.isAvailable()) {
+                Class<?> methodHandles = Class.forName("java.lang.invoke.MethodHandles");
+                Object lookup = methodHandles.getMethod("lookup").invoke(null);
+                Method privateLookupIn = methodHandles.getMethod("privateLookupIn",
+                        Class.class,
+                        Class.forName("java.lang.invoke.MethodHandles$Lookup"));
+                Object privateLookup = privateLookupIn.invoke(null, mockedType, lookup);
+                strategy = ClassLoadingStrategy.UsingLookup.of(privateLookup);
+            } else if (ClassInjector.UsingReflection.isAvailable()) {
+                strategy = ClassLoadingStrategy.Default.INJECTION;
+            } else {
+                throw new IllegalStateException("No code generation strategy available");
+            }
+
+            return objenesis.newInstance(builder.make()
+                    .load(SearchingClassLoader.combineLoadersOf(mockedType, ancilliaryTypes), strategy)
+                    .getLoaded());
+            
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+                | SecurityException | ClassNotFoundException e) {
+            throw new RuntimeException("Exception in code generation strategy available", e);
         }
-        catch (CodeGenerationException e) {
-            // Note: I've only been able to manually test this.  It exists to help people writing
-            //       Eclipse plug-ins or using other environments that have sophisticated class loader
-            //       structures.
-            throw new IllegalArgumentException("could not imposterise " + mockedType, e);
-        }
-    }
-    
-    private Object proxy(Class<?> proxyClass, final Invokable mockObject) {
-        final Factory proxy = (Factory)objenesis.newInstance(proxyClass);
-        proxy.setCallbacks(new Callback[] {
-            new InvocationHandler() {
-                public Object invoke(Object receiver, Method method, Object[] args) throws Throwable {
-                    return mockObject.invoke(new Invocation(receiver, method, args));
-                }
-            },
-            NoOp.INSTANCE
-        });
-        return proxy;
-    }
-    
-    private Class<?>[] prepend(Class<?> first, Class<?>... rest) {
-        Class<?>[] all = new Class<?>[rest.length+1];
-        all[0] = first;
-        System.arraycopy(rest, 0, all, 1, rest.length);
-        return all;
     }
 
     private static Method findFinalizeMethod() {
@@ -155,6 +138,7 @@ public class ClassImposteriser implements Imposteriser {
             throw new IllegalStateException("Could not find finalize method on Object");
         }
     }
-    
-    public static class ClassWithSuperclassToWorkAroundCglibBug {}
+
+    public static class ClassWithSuperclassToWorkAroundCglibBug {
+    }
 }

--- a/jmock-legacy/src/test/java/org/jmock/test/acceptance/AbstractImposteriserParameterResolver.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/acceptance/AbstractImposteriserParameterResolver.java
@@ -1,0 +1,56 @@
+package org.jmock.test.acceptance;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.jmock.api.Imposteriser;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+/**
+ * Provide known instances of Code Generating ClassImposteriser for tests
+ * Because reflection can't be used for class imposterisation
+ * 
+ * This is a Java 7 implementation, Java 8 is a lot simpler!
+ * 
+ * @author oliverbye
+ *
+ */
+public abstract class AbstractImposteriserParameterResolver implements ArgumentsProvider {
+
+    private final Imposteriser[] imposters;
+
+    public AbstractImposteriserParameterResolver(Imposteriser... imposters) {
+        this.imposters = imposters;
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Arrays.stream(imposters).map(new FunctionImplementation());
+    }
+
+    // Java1.7 needs
+    private static final class FunctionImplementation implements Function<Imposteriser, Arguments> {
+
+        @Override
+        public Arguments apply(Imposteriser i) {
+            return new ArgumentSupplier(i);
+        }
+    }
+
+    private static final class ArgumentSupplier implements Arguments {
+        private Imposteriser i;
+
+        public ArgumentSupplier(Imposteriser i) {
+            this.i = i;
+        }
+
+        @Override
+        public Object[] get() {
+            return new Object[] { i };
+        }
+    }
+
+}

--- a/jmock-legacy/src/test/java/org/jmock/test/acceptance/FinalizerIsIgnoredAcceptanceTests.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/acceptance/FinalizerIsIgnoredAcceptanceTests.java
@@ -1,25 +1,27 @@
 package org.jmock.test.acceptance;
 
-import junit.framework.TestCase;
-
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.api.Imposteriser;
+import org.jmock.test.unit.lib.legacy.CodeGeneratingImposteriserParameterResolver;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
-public class FinalizerIsIgnoredAcceptanceTests extends TestCase {
+public class FinalizerIsIgnoredAcceptanceTests {
+
     public static class ClassWithFinalizer {
         @Override
         protected void finalize() throws Throwable {
             super.finalize();
         }
     }
-    
-    Mockery mockery = new Mockery() {{
-        setImposteriser(ClassImposteriser.INSTANCE);
-    }};
-    
-    ClassWithFinalizer mock = mockery.mock(ClassWithFinalizer.class, "mock");
-    
-    public void testIgnoresFinalizerInMockedClasses() throws Throwable {
+
+    Mockery mockery = new Mockery();
+
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void testIgnoresFinalizerInMockedClasses(Imposteriser imposteriserImpl) throws Throwable {
+        mockery.setImposteriser(imposteriserImpl);
+        ClassWithFinalizer mock = mockery.mock(ClassWithFinalizer.class, "mock");
         mock.finalize();
     }
 }

--- a/jmock-legacy/src/test/java/org/jmock/test/acceptance/InvocationDescriptionAcceptanceTests.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/acceptance/InvocationDescriptionAcceptanceTests.java
@@ -1,29 +1,30 @@
 package org.jmock.test.acceptance;
 
-import org.jmock.Expectations;
-import org.jmock.integration.junit4.JUnit4Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
+import org.jmock.Expectations;
+import org.jmock.api.Imposteriser;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.test.unit.lib.legacy.ImposteriserParameterResolver;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 /**
  * @author Steve Freeman 2012 http://www.jmock.org
  */
 public class InvocationDescriptionAcceptanceTests {
   private static final String UNEXPECTED_ARGUMENT = "unexpected argument";
-  private final JUnit4Mockery aMockContext = new JUnit4Mockery() {{
-        setImposteriser(ClassImposteriser.INSTANCE);
-      }};
+  private final JUnit4Mockery aMockContext = new JUnit4Mockery();
 
     private final SubBean aSubBean = aMockContext.mock(SubBean.class);
     private final Collaborator aCollab = aMockContext.mock(Collaborator.class);
 
     // https://github.com/jmock-developers/jmock-library/issues/20
-    @Test
-    public void doesNotModifyInvocationsWhileReportingFailure() {
+    @ParameterizedTest
+    @ArgumentsSource(ImposteriserParameterResolver.class)
+    public void doesNotModifyInvocationsWhileReportingFailure(Imposteriser imposteriserImpl) {
       final Bean lBean = new Bean(aSubBean);
 
       aMockContext.checking(new Expectations() {{

--- a/jmock-legacy/src/test/java/org/jmock/test/acceptance/MockingClassesAcceptanceTests.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/acceptance/MockingClassesAcceptanceTests.java
@@ -1,36 +1,44 @@
 package org.jmock.test.acceptance;
 
+import static org.junit.Assert.assertSame;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.api.Imposteriser;
+import org.jmock.test.unit.lib.legacy.CodeGeneratingImposteriserParameterResolver;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
-import junit.framework.TestCase;
+public class MockingClassesAcceptanceTests {
 
-public class MockingClassesAcceptanceTests extends TestCase {
-    public static final class FinalClass {}
-    
+    public static final class FinalClass {
+    }
+
     public static class ClassToMock {
         public FinalClass returnInstanceOfFinalClass() {
             return null;
         }
     }
-    
-    Mockery context = new Mockery() {{
-        setImposteriser(ClassImposteriser.INSTANCE);
-    }};
-    
-    ClassToMock mock = context.mock(ClassToMock.class);
-    
-    public void testCanMockClassesWithMethodsThatReturnFinalClasses() {
+
+    Mockery context = new Mockery();
+
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void testCanMockClassesWithMethodsThatReturnFinalClasses(Imposteriser imposteriserImpl) {
+        context.setImposteriser(imposteriserImpl);
+
+        final ClassToMock mock = context.mock(ClassToMock.class);
         final FinalClass result = new FinalClass();
-        
-        context.checking(new Expectations() {{
-            oneOf (mock).returnInstanceOfFinalClass(); will(returnValue(result));
-        }});
-        
+
+        context.checking(new Expectations() {
+            {
+                oneOf(mock).returnInstanceOfFinalClass();
+                will(returnValue(result));
+            }
+        });
+
         // This should not crash
-        
+
         assertSame(result, mock.returnInstanceOfFinalClass());
     }
 }
-

--- a/jmock-legacy/src/test/java/org/jmock/test/acceptance/MockingImplementationOfGenericTypeAcceptanceTests.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/acceptance/MockingImplementationOfGenericTypeAcceptanceTests.java
@@ -1,73 +1,92 @@
 package org.jmock.test.acceptance;
 
-import junit.framework.TestCase;
-
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.api.Imposteriser;
 import org.jmock.integration.junit4.JUnit4Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.test.unit.lib.legacy.CodeGeneratingImposteriserParameterResolver;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
+public class MockingImplementationOfGenericTypeAcceptanceTests {
+    private Mockery context = new JUnit4Mockery();
 
-public class MockingImplementationOfGenericTypeAcceptanceTests extends TestCase {
-    private Mockery context = new JUnit4Mockery() {{
-        setImposteriser(ClassImposteriser.INSTANCE);
-    }};
-    
-    public void testWhenDefinedAndInvokedThroughClass() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void testWhenDefinedAndInvokedThroughClass(Imposteriser imposteriserImpl) throws Exception {
+        context.setImposteriser(imposteriserImpl);
         final AnImplementation mock = context.mock(AnImplementation.class);
 
-        context.checking(new Expectations() {{
-            oneOf (mock).doSomethingWith("a");
-        }});
-            
+        context.checking(new Expectations() {
+            {
+                oneOf(mock).doSomethingWith("a");
+            }
+        });
+
         mock.doSomethingWith("a");
     }
-    
-    public void testWhenDefinedThroughClassAndInvokedThroughMethod() throws Exception {
+
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void testWhenDefinedThroughClassAndInvokedThroughMethod(Imposteriser imposteriserImpl) throws Exception {
+        context.setImposteriser(imposteriserImpl);
         final AnImplementation mock = context.mock(AnImplementation.class);
 
-        context.checking(new Expectations() {{
-            oneOf (mock).doSomethingWith("a");
-        }});
-        
+        context.checking(new Expectations() {
+            {
+                oneOf(mock).doSomethingWith("a");
+            }
+        });
+
         // Note: this is invoked through a "bridge" method and so the method
         // invoked when expectations are checked appears to be different from
         // that invoked when expectations are captured.
-        ((AnInterface<String>)mock).doSomethingWith("a");
+        ((AnInterface<String>) mock).doSomethingWith("a");
     }
-    
-    public void DONTtestAndBoxedNativeParameterIgnoingIsADocumentationWhenDefinedThroughClassAndInvokedThroughMethod() throws Exception {
+
+    @Disabled
+    public void DONTtestAndBoxedNativeParameterIgnoingIsADocumentationWhenDefinedThroughClassAndInvokedThroughMethod()
+            throws Exception {
         final AnImplementation mock = context.mock(AnImplementation.class);
 
-        context.checking(new Expectations() {{
-            oneOf (mock).doSomethingWith(with(any(Integer.class)));
-        }});
-        
+        context.checking(new Expectations() {
+            {
+                oneOf(mock).doSomethingWith(with(any(Integer.class)));
+            }
+        });
+
         // Note: this is invoked through a "bridge" method and so the method
         // invoked when expectations are checked appears to be different from
         // that invoked when expectations are captured.
-        ((AnInterface<String>)mock).doSomethingWith("a");
+        ((AnInterface<String>) mock).doSomethingWith("a");
     }
-    
 
-    public void testWhenDefinedAndInvokedThroughInterface() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void testWhenDefinedAndInvokedThroughInterface(Imposteriser imposteriserImpl) throws Exception {
+        context.setImposteriser(imposteriserImpl);
         final AnInterface<String> mock = context.mock(AnImplementation.class);
 
-        context.checking(new Expectations() {{
-            oneOf (mock).doSomethingWith("a");
-        }});
+        context.checking(new Expectations() {
+            {
+                oneOf(mock).doSomethingWith("a");
+            }
+        });
 
         mock.doSomethingWith("a");
     }
 
     public interface AnInterface<T> {
         void doSomethingWith(T arg);
+
         void doSomethingWith(int arg);
     }
 
     public static class AnImplementation implements AnInterface<String> {
         public void doSomethingWith(String arg) {
         }
+
         public void doSomethingWith(int arg) {
         }
     }

--- a/jmock-legacy/src/test/java/org/jmock/test/acceptance/MockingPackageProtectedTypeAcceptanceTests.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/acceptance/MockingPackageProtectedTypeAcceptanceTests.java
@@ -4,16 +4,19 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
-import junit.framework.TestCase;
-
 import org.jmock.Mockery;
+import org.jmock.api.Imposteriser;
 import org.jmock.internal.CaptureControl;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.test.unit.lib.legacy.ImposteriserParameterResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 
-public class MockingPackageProtectedTypeAcceptanceTests extends TestCase {
+public class MockingPackageProtectedTypeAcceptanceTests {
     Mockery mockery = new Mockery();
 
+    @Test
     public void testCanCreateReflectionProxyOfPackageProtectedType() {
         Class<?> typeToProxy = PackageProtectedType.class;
         
@@ -26,13 +29,11 @@ public class MockingPackageProtectedTypeAcceptanceTests extends TestCase {
                 }
             });
     }
-    
-    public void testCanMockPackageProtectedTypeWithDefaultImposteriser() {
-        mockery.mock(PackageProtectedType.class, "mock");
-    }
-    
-    public void testCanMockPackageProtectedTypeWithObjenesisImposteriser() {
-        mockery.setImposteriser(ClassImposteriser.INSTANCE);
+        
+    @ParameterizedTest
+    @ArgumentsSource(ImposteriserParameterResolver.class)
+    public void testCanMockPackageProtectedTypeWithObjenesisImposteriser(Imposteriser imposteriserImpl) {
+        mockery.setImposteriser(imposteriserImpl);
         mockery.mock(PackageProtectedType.class, "mock");
     }
 }

--- a/jmock-legacy/src/test/java/org/jmock/test/acceptance/RedeclaredObjectMethodsAcceptanceTests.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/acceptance/RedeclaredObjectMethodsAcceptanceTests.java
@@ -1,61 +1,76 @@
 package org.jmock.test.acceptance;
 
-import java.util.Vector;
+import static org.junit.Assert.assertEquals;
 
-import junit.framework.TestCase;
+import java.util.Vector;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.api.ExpectationError;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.api.Imposteriser;
+import org.jmock.test.unit.lib.legacy.CodeGeneratingImposteriserParameterResolver;
+import org.jmock.test.unit.lib.legacy.ImposteriserParameterResolver;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 // Fixes issue JMOCK-96
-public class RedeclaredObjectMethodsAcceptanceTests extends TestCase {
+public class RedeclaredObjectMethodsAcceptanceTests {
+
+    Mockery context = new Mockery();
+
     public interface MockedInterface {
         String toString();
     }
-    
+
     public static class MockedClass {
         @Override
         public String toString() {
             return "not mocked";
         }
     }
-    
-    public void testCanRedeclareObjectMethodsInMockedInterfaces() {
-        Mockery context = new Mockery();
+
+    @ParameterizedTest
+    @ArgumentsSource(ImposteriserParameterResolver.class)
+    public void testCanRedeclareObjectMethodsInMockedInterfaces(Imposteriser imposteriserImpl) {
+        context.setImposteriser(imposteriserImpl);
         MockedInterface mock = context.mock(MockedInterface.class, "X");
-        
+
         assertEquals("X", mock.toString());
     }
-    
-    public void testCanRedeclareObjectMethodsInMockedClasses() {
-        Mockery context = new Mockery();
-        context.setImposteriser(ClassImposteriser.INSTANCE);
+
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void testCanRedeclareObjectMethodsInMockedClasses(Imposteriser imposteriserImpl) {
+
+        context.setImposteriser(imposteriserImpl);
         MockedClass mock = context.mock(MockedClass.class, "X");
-        
+
         assertEquals("X", mock.toString());
     }
-    
-    /* 
+
+    /*
      * Adapted from Jira issue JMOCK-96
      */
-    @SuppressWarnings({"cast", "unchecked"})
-    public void testUseMockObjectHangs1() {
-        Mockery context = new Mockery();
-        context.setImposteriser(ClassImposteriser.INSTANCE);
-        final Vector<Object> mock = (Vector<Object>)context.mock(Vector.class);
-        
-        context.checking(new Expectations() {{
-            atLeast(1).of (mock).size(); will(returnValue(2));
-        }});
-        
+    @SuppressWarnings("unchecked")
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void testUseMockObjectHangs1(Imposteriser imposteriserImpl) {
+
+        context.setImposteriser(imposteriserImpl);
+        final Vector<Object> mock = (Vector<Object>) context.mock(Vector.class);
+
+        context.checking(new Expectations() {
+            {
+                atLeast(1).of(mock).size();
+                will(returnValue(2));
+            }
+        });
+
         try {
             for (int i = 0; i < mock.size(); i++) {
                 System.out.println("Vector entry " + i + " = " + mock.get(i));
             }
-        }
-        catch (ExpectationError error) {
+        } catch (ExpectationError error) {
             // expected
         }
     }

--- a/jmock-legacy/src/test/java/org/jmock/test/unit/lib/legacy/ClassImposteriserTests.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/unit/lib/legacy/ClassImposteriserTests.java
@@ -1,13 +1,8 @@
 package org.jmock.test.unit.lib.legacy;
 
-import org.jmock.api.Action;
-import org.jmock.api.Imposteriser;
-import org.jmock.api.Invocation;
-import org.jmock.api.Invokable;
-import org.jmock.lib.action.ReturnValueAction;
-import org.jmock.lib.action.VoidAction;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
@@ -16,14 +11,17 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.jmock.api.Action;
+import org.jmock.api.Imposteriser;
+import org.jmock.api.Invocation;
+import org.jmock.api.Invokable;
+import org.jmock.lib.action.ReturnValueAction;
+import org.jmock.lib.action.VoidAction;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 public class ClassImposteriserTests {
     Action action = new ReturnValueAction("result");
-    
-    Imposteriser imposteriser = ClassImposteriser.INSTANCE;
     
     @SuppressWarnings("ClassInitializerMayBeStatic")
     public static class ConcreteClassWithNastyConstructor {
@@ -71,8 +69,9 @@ public class ClassImposteriserTests {
         public String foo() {return "original result";}
     }
     
-    @Test
-    public void canImposteriseInterfacesAndNonFinalInstantiableClasses() {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void canImposteriseInterfacesAndNonFinalInstantiableClasses(Imposteriser imposteriser) {
         assertTrue("should report that it can imposterise interfaces",
                    imposteriser.canImposterise(Runnable.class));
         assertTrue("should report that it can imposterise classes",
@@ -91,32 +90,36 @@ public class ClassImposteriserTests {
                    !imposteriser.canImposterise(void.class));
     }
 
-    @Test
-    public void canImposteriseAConcreteClassWithoutCallingItsConstructorOrInstanceInitialiserBlocks() {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void canImposteriseAConcreteClassWithoutCallingItsConstructorOrInstanceInitialiserBlocks(Imposteriser imposteriser) {
         ConcreteClassWithNastyConstructor imposter = 
             imposteriser.imposterise(action, ConcreteClassWithNastyConstructor.class);
         
         assertEquals("result", imposter.foo());
     }
 
-    @Test
-    public void canImposteriseAnInterface() {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void canImposteriseAnInterface(Imposteriser imposteriser) {
         AnInterface imposter = 
             imposteriser.imposterise(action, AnInterface.class);
         
         assertEquals("result", imposter.foo());
     }
 
-    @Test
-    public void canImposteriseAClassWithAPrivateConstructor() {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void canImposteriseAClassWithAPrivateConstructor(Imposteriser imposteriser) {
         AClassWithAPrivateConstructor imposter = 
             imposteriser.imposterise(action, AClassWithAPrivateConstructor.class);
         
         assertEquals("result", imposter.foo());
     }
 
-    @Test
-    public void canImposteriseAClassInASignedJarFile() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void canImposteriseAClassInASignedJarFile(Imposteriser imposteriser) throws Exception {
         File jarFile = new File("../testjar/target/signed.jar");
         
         assertTrue("Signed JAR file does not exist (use Ant to build it", jarFile.exists());
@@ -142,8 +145,9 @@ public class ClassImposteriserTests {
     }
     
     // See issue JMOCK-150
-    @Test
-    public void cannotImposteriseAClassWithAFinalToStringMethod() {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void cannotImposteriseAClassWithAFinalToStringMethod(Imposteriser imposteriser) {
         assertTrue("should not be able to imposterise it", !imposteriser.canImposterise(ClassWithFinalToStringMethod.class));
         
         try {
@@ -156,8 +160,9 @@ public class ClassImposteriserTests {
     }
 
     // See issue JMOCK-256 (Github #36)
-    @Test
-    public void doesntDelegateFinalizeMethod() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void doesntDelegateFinalizeMethod(Imposteriser imposteriser) throws Exception {
         Invokable failIfInvokedAction = new Invokable() {
             public Object invoke(Invocation invocation) throws Throwable {
                 fail("invocation should not have happened");
@@ -172,8 +177,9 @@ public class ClassImposteriserTests {
     public interface EmptyInterface {}
     
     // See issue JMOCK-145
-    @Test
-    public void worksAroundBugInCglibWhenAskedToImposteriseObject() {
+    @ParameterizedTest
+    @ArgumentsSource(CodeGeneratingImposteriserParameterResolver.class)
+    public void worksAroundBugInCglibWhenAskedToImposteriseObject(Imposteriser imposteriser) {
         imposteriser.imposterise(new VoidAction(), Object.class);
         
         imposteriser.imposterise(new VoidAction(), Object.class, EmptyInterface.class);

--- a/jmock-legacy/src/test/java/org/jmock/test/unit/lib/legacy/CodeGeneratingImposteriserParameterResolver.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/unit/lib/legacy/CodeGeneratingImposteriserParameterResolver.java
@@ -1,0 +1,13 @@
+package org.jmock.test.unit.lib.legacy;
+
+import org.jmock.lib.imposters.ByteBuddyClassImposteriser;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.test.acceptance.AbstractImposteriserParameterResolver;
+
+public class CodeGeneratingImposteriserParameterResolver extends AbstractImposteriserParameterResolver {
+
+    public CodeGeneratingImposteriserParameterResolver() {
+        super(ByteBuddyClassImposteriser.INSTANCE,
+                ClassImposteriser.INSTANCE);
+    }
+}

--- a/jmock-legacy/src/test/java/org/jmock/test/unit/lib/legacy/ImposteriserParameterResolver.java
+++ b/jmock-legacy/src/test/java/org/jmock/test/unit/lib/legacy/ImposteriserParameterResolver.java
@@ -1,0 +1,22 @@
+package org.jmock.test.unit.lib.legacy;
+
+import org.jmock.lib.JavaReflectionImposteriser;
+import org.jmock.lib.imposters.ByteBuddyClassImposteriser;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.test.acceptance.AbstractImposteriserParameterResolver;
+
+/**
+ * Provide known instances of ClassImposteriser for tests
+ * 
+ * @author oliverbye
+ *
+ */
+public class ImposteriserParameterResolver extends AbstractImposteriserParameterResolver {
+
+    public ImposteriserParameterResolver() {
+        super(ByteBuddyClassImposteriser.INSTANCE,
+                ClassImposteriser.INSTANCE,
+                JavaReflectionImposteriser.INSTANCE);
+    }
+
+}

--- a/jmock/pom.xml
+++ b/jmock/pom.xml
@@ -27,10 +27,16 @@
             <version>${project.version}</version>
         </dependency>
 
+<!-- 
         <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib</artifactId>
         </dependency>
+ -->
+<dependency>
+    <groupId>net.bytebuddy</groupId>
+    <artifactId>byte-buddy</artifactId>
+</dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>

--- a/jmock/pom.xml
+++ b/jmock/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
@@ -9,7 +10,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0</version>
+        <version>2.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -17,7 +18,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
+            <!-- Don't force dependents to use junit4 -->
         </dependency>
 
         <dependency>
@@ -27,16 +29,11 @@
             <version>${project.version}</version>
         </dependency>
 
-<!-- 
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib</artifactId>
-        </dependency>
- -->
-<dependency>
-    <groupId>net.bytebuddy</groupId>
-    <artifactId>byte-buddy</artifactId>
-</dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency
+        >
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
@@ -86,9 +83,6 @@
                 </executions>
                 <configuration>
                     <executable>java</executable>
-                    <!-- java -cp ~/.m2/repository/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar:~.m2/repository/org/ow2/asm/asm-util/4.1/asm-util-4.1.jar 
-                        org.objectweb.asm.util.ASMifier target/classes/org/jmock/Expectations.class 
-                        > Xpectations.java -->
                     <commandlineArgs>-cp %classpath:target/classes
                         org.jmock.ExpectationsCreator</commandlineArgs>
                 </configuration>

--- a/jmock/pom.xml
+++ b/jmock/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jmock/src/test/java/org/jmock/test/unit/support/MethodFactory.java
+++ b/jmock/src/test/java/org/jmock/test/unit/support/MethodFactory.java
@@ -4,8 +4,8 @@ package org.jmock.test.unit.support;
 
 import java.lang.reflect.Method;
 
-import net.sf.cglib.core.Constants;
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 public class MethodFactory extends ClassLoader {
@@ -30,13 +30,13 @@ public class MethodFactory extends ClassLoader {
 			protected Class<?> findClass(String interfaceName) {
 				ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
 
-				writer.visit(CLASS_FORMAT_VERSION, Constants.ACC_PUBLIC
-						| Constants.ACC_INTERFACE,
+				writer.visit(CLASS_FORMAT_VERSION, Opcodes.ACC_PUBLIC
+						| Opcodes.ACC_INTERFACE,
 						nameToClassFormat(interfaceName), null,
 						"java/lang/Object", null /* interfaces */);
 
-				writer.visitMethod(Constants.ACC_PUBLIC
-						| Constants.ACC_ABSTRACT, methodName,
+				writer.visitMethod(Opcodes.ACC_PUBLIC
+						| Opcodes.ACC_ABSTRACT, methodName,
 						methodDescriptor(returnType, argTypes), null,
 						classNamesInClassFormat(exceptionTypes));
 

--- a/jmock/src/test/java/org/jmock/test/unit/support/SyntheticEmptyInterfaceClassLoader.java
+++ b/jmock/src/test/java/org/jmock/test/unit/support/SyntheticEmptyInterfaceClassLoader.java
@@ -3,43 +3,42 @@
  */
 package org.jmock.test.unit.support;
 
-import net.sf.cglib.core.Constants;
-import org.objectweb.asm.ClassWriter;
-
 import static org.jmock.test.unit.support.MethodFactory.CLASS_FORMAT_VERSION;
 
 import java.util.regex.Pattern;
 
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+
 public class SyntheticEmptyInterfaceClassLoader extends ClassLoader {
     private Pattern namePattern;
-    
+
     public SyntheticEmptyInterfaceClassLoader() {
         this(".*");
     }
-    
+
     public SyntheticEmptyInterfaceClassLoader(String namePatternRegex) {
         namePattern = Pattern.compile(namePatternRegex);
     }
-    
+
     @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
         if (namePattern.matcher(name).matches()) {
             return synthesiseInterface(name);
-        }
-        else {
+        } else {
             throw new ClassNotFoundException(name);
         }
     }
 
     private Class<?> synthesiseInterface(String name) throws ClassFormatError {
         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-                writer.visit(CLASS_FORMAT_VERSION,
-                             Constants.ACC_PUBLIC|Constants.ACC_INTERFACE,
-                             MethodFactory.nameToClassFormat(name),
-                             null,
-                             "java/lang/Object",
-                             null /* interfaces */);
-        
+        writer.visit(CLASS_FORMAT_VERSION,
+                Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE,
+                MethodFactory.nameToClassFormat(name),
+                null,
+                "java/lang/Object",
+                null /* interfaces */);
+
         byte[] b = writer.toByteArray();
 
         return defineClass(name, b, 0, b.length);

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.jmock</groupId>
     <artifactId>jmock-parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>jMock 2 Parent</name>
 
@@ -44,15 +44,18 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
 
         <downloadSources>true</downloadSources>
         <hamcrest.version>1.3</hamcrest.version>
         <hamcrest.src>hamcrest-src</hamcrest.src>
         <junit.version>4.12</junit.version>
-        <cglib.version>3.2.8</cglib.version>
         <asm.version>6.2.1</asm.version>
         <objenesis.version>2.6</objenesis.version>
         <bsh.version>2.0b6</bsh.version>
+        <junit.jupiter.version>5.3.1</junit.jupiter.version>
+        <bytebuddy.version>1.9.1</bytebuddy.version>
     </properties>
 
     <modules>
@@ -60,6 +63,7 @@
         <module>jmock</module>
         <module>jmock-junit3</module>
         <module>jmock-junit4</module>
+        <module>jmock-imposters</module>
         <module>jmock-legacy</module>
         <module>jmock-example</module>
     </modules>
@@ -99,14 +103,6 @@
 
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
-                    </configuration>
-                </plugin>
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -174,6 +170,7 @@
 
     <dependencyManagement>
         <dependencies>
+
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
@@ -184,6 +181,7 @@
                 <artifactId>hamcrest-library</artifactId>
                 <version>${hamcrest.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
@@ -191,31 +189,50 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.3.1</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache-extras.beanshell</groupId>
                 <artifactId>bsh</artifactId>
                 <version>${bsh.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>1.9.1</version>
-            </dependency>
-            <dependency>
-                <groupId>cglib</groupId>
-                <artifactId>cglib</artifactId>
-                <version>${cglib.version}</version>
-            </dependency>
-            <dependency>
-                <!-- Instead of net.sf.asm in cglib -->
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
                 <version>${objenesis.version}</version>
                 <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${bytebuddy.version}</version>
+            </dependency>
+            <dependency>
+                <!-- Instead of net.sf.asm in cglib -->
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.thoughtworks.qdox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.jmock</groupId>
     <artifactId>jmock-parent</artifactId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.9.0</version>
     <packaging>pom</packaging>
     <name>jMock 2 Parent</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
                 <version>${bsh.version}</version>
             </dependency>
             <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>1.9.1</version>
+            </dependency>
+            <dependency>
                 <groupId>cglib</groupId>
                 <artifactId>cglib</artifactId>
                 <version>${cglib.version}</version>

--- a/testjar/pom.xml
+++ b/testjar/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testjar/pom.xml
+++ b/testjar/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.jmock</groupId>
         <artifactId>jmock-parent</artifactId>
-        <version>2.9.0</version>
+        <version>2.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
The aim is to make this as seamless as possible.
Strategies (probably going with B)
A)
- Switch ClassImposteriser to use ByteBuddy
- Make ClassImposteriser backward compatible and forward compatible with java 7,8,9,10,11
- Move old 2.9.0 ClassImposteriser to CGLIBClassImposteriser (and deprecate it)
- Make CGLIBClassImposteriser available just in case backward compatibility fails

B)
- Leave ClassImposteriser using CGLIB. Deprecate in favour of ByteBuddyClassImposteriser
-- See if we can address Java11 issue with CGLIB ClassImposteriser
- Detect running in Java11 and issue warnings
- Detect known issues (e.g. mocking java.*)
-- Warn if in Java<11
-- llegalArgumentException with description and URL to issue