### PR TITLE
Return -1 as delay for removed elements in DeltaQueue

### DIFF
--- a/jmock/src/main/java/org/jmock/lib/concurrent/internal/DeltaQueue.java
+++ b/jmock/src/main/java/org/jmock/lib/concurrent/internal/DeltaQueue.java
@@ -42,7 +42,7 @@ public class DeltaQueue<T> {
             next = next.next;
         }
         if (next == null) {
-            return 0;
+            return -1;
         }
         return ret;
     }

--- a/jmock/src/main/java/org/jmock/lib/concurrent/internal/DeltaQueue.java
+++ b/jmock/src/main/java/org/jmock/lib/concurrent/internal/DeltaQueue.java
@@ -42,7 +42,7 @@ public class DeltaQueue<T> {
             next = next.next;
         }
         if (next == null) {
-            throw new IllegalStateException("Element not found in the delay queue");
+            return 0;
         }
         return ret;
     }

--- a/jmock/src/test/java/org/jmock/test/unit/lib/concurrent/DeterministicSchedulerTests.java
+++ b/jmock/src/test/java/org/jmock/test/unit/lib/concurrent/DeterministicSchedulerTests.java
@@ -146,10 +146,7 @@ public class DeterministicSchedulerTests extends MockObjectTestCase {
 
         scheduler.tick(2, TimeUnit.MILLISECONDS);
 
-        try {
-            assertEquals(0, task1.getDelay(TimeUnit.MILLISECONDS));
-            fail("should have thrown IllegalStateException");
-        } catch (IllegalStateException expected) {}
+        assertEquals(-1, task1.getDelay(TimeUnit.MILLISECONDS));
     }
     
     public class ExampleException extends Exception {}

--- a/jmock/src/test/java/org/jmock/test/unit/lib/concurrent/internal/DeltaQueueTests.java
+++ b/jmock/src/test/java/org/jmock/test/unit/lib/concurrent/internal/DeltaQueueTests.java
@@ -167,4 +167,11 @@ public class DeltaQueueTests extends TestCase {
         
         assertFalse(deltaQueue.remove(elementC));
     }
+
+    public void testDelayIsMinusOneWhenElementIsAlreadyRemoved() {
+        deltaQueue.add(1L, elementA);
+        deltaQueue.remove(elementA);
+
+        assertEquals("delay", -1, deltaQueue.delay(elementA));
+    }
 }


### PR DESCRIPTION
Guava's `TimeoutFuture` now [always checks the delay](https://github.com/google/guava/blob/master/guava/src/com/google/common/util/concurrent/TimeoutFuture.java#L119-L128) of the ScheduledFuture before cancelling the task, which means that when we use it with `DeterministicExecutor`, it will always throw an exception before cancelling the task.