### PR TITLE
Adapt to changed output in junit 4.13

### DIFF
--- a/jmock-junit4/src/test/java/org/jmock/test/acceptance/junit4/JUnit4TestRunnerTests.java
+++ b/jmock-junit4/src/test/java/org/jmock/test/acceptance/junit4/JUnit4TestRunnerTests.java
@@ -47,9 +47,8 @@ public class JUnit4TestRunnerTests extends TestCase {
     public void testDetectsNonPublicBeforeMethodsCorrectly() {
         listener.runTestIn(JUnit4TestWithNonPublicBeforeMethod.class);
         listener.assertTestFailedWith(Throwable.class);
-        assertEquals("should have detected non-public before method",
-                "Method before() should be public",
-                       listener.failure.getMessage());
+        assertTrue("should have detected non-public before method",
+                listener.failure.getMessage().contains("Method before() should be public"));
     }
     
     public void testAutoInstantiatesMocks() {


### PR DESCRIPTION
JUnit 4.13 includes a change in the way invalid test classes are reported: https://github.com/junit-team/junit4/pull/1286, causing one jmock test to fail.  This commit adapts to the change, thereby clearing the way for https://github.com/jmock-developers/jmock-library/pull/182.