### PR TITLE
Bump org.junit.jupiter from 5.10.2 to 5.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,8 @@
         <asm.version>8.0.1</asm.version>
         <objenesis.version>3.3</objenesis.version>
         <bsh.version>2.0b6</bsh.version>
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.13.0</junit.jupiter.version>
+        <junit.platform.launcher.version>1.13.0</junit.platform.launcher.version>
         <bytebuddy.version>1.14.13</bytebuddy.version>
     </properties>
 
@@ -281,7 +282,7 @@
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-launcher</artifactId>
-                <version>1.10.2</version>
+                <version>${junit.platform.launcher.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR bumps org.junit.jupiter from 5.10.2 to 5.13.0.

It transitively bumps junit.platform.launcher from 1.10.2 to 1.13.0. The latter is needed as JUnit 5.13.0 is dependent on platform launcher 1.13.0, but 1.13.0 was given as a static number in the POM.

This PR implicitly closes #302. 