### PR TITLE
Add support for Java 17 and 21 to the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java: [ 8, 11 ]
+        java: [ 8, 11, 17, 21 ]
         experimental: [false]
-        include:
-          - java: 17
-            experimental: true
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.java }}

--- a/jmock-imposters-tests/pom.xml
+++ b/jmock-imposters-tests/pom.xml
@@ -69,17 +69,29 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>java9-and-above</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/jmock-imposters-tests/pom.xml
+++ b/jmock-imposters-tests/pom.xml
@@ -69,6 +69,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,11 @@
         <downloadSources>true</downloadSources>
         <hamcrest.version>2.2</hamcrest.version>
         <junit.version>4.13.2</junit.version>
-        <asm.version>8.0.1</asm.version>
+        <asm.version>9.8</asm.version>
         <objenesis.version>3.3</objenesis.version>
         <bsh.version>2.0b6</bsh.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
-        <bytebuddy.version>1.14.13</bytebuddy.version>
+        <bytebuddy.version>1.17.6</bytebuddy.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This change updates the GitHub Actions workflow to include Java 17 and 21 in the build matrix.

To ensure compatibility with these newer Java versions, the following changes were also made:
- The `asm` and `byte-buddy` dependencies were updated to versions that support newer JDKs.
- The `maven-surefire-plugin` was configured to pass `--add-opens` arguments to the JVM to allow reflective access required by the tests.