### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Maven Build
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/jmock-developers/jmock-library/security/code-scanning/2](https://github.com/jmock-developers/jmock-library/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and builds with Maven, it only needs read access to repository contents. The best way to do this is to add the following at the top level of the workflow (after the `name` and before `on`), or at the job level if only specific jobs need it. In this case, adding it at the workflow level is simplest and most maintainable. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
