### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Maven deploy snapshot
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jmock-developers/jmock-library/security/code-scanning/1](https://github.com/jmock-developers/jmock-library/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the top level of the workflow (before `jobs:`), so it applies to all jobs unless overridden. For a Maven deploy workflow, the minimal required permission is usually `contents: read`, unless the workflow needs to create issues, pull requests, or interact with other resources. If later steps require additional permissions, they can be added as needed. The change should be made at the top of the `.github/workflows/snapshot.yml` file, immediately after the `name:` and before `on:` or `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
