### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: write
+  pull-requests: write
 name: Maven deploy release
 # Reset before repeated testing
 # git push --delete origin 2.13.0


### PR DESCRIPTION
Potential fix for [https://github.com/jmock-developers/jmock-library/security/code-scanning/3](https://github.com/jmock-developers/jmock-library/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow pushes commits and tags and creates pull requests, it needs `contents: write` and `pull-requests: write` permissions. The `contents: write` permission is required for pushing commits and tags, and `pull-requests: write` is needed for creating pull requests. The `permissions` block should be added at the top level of the workflow (after the `name` and before `on:`) to apply to all jobs, unless more granular control is needed. No changes to the steps or other logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
